### PR TITLE
feat: CSV export for audit reports

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -12,6 +12,7 @@ public class CliOptions
     public bool HtmlIncludePass { get; set; }
     public string? HtmlTitle { get; set; }
     public bool Markdown { get; set; }
+    public bool Csv { get; set; }
     public bool Sarif { get; set; }
     public bool SarifIncludePass { get; set; }
     public string? OutputFile { get; set; }
@@ -655,6 +656,10 @@ public static class CliParser
                     options.Markdown = true;
                     break;
 
+                case "--csv":
+                    options.Csv = true;
+                    break;
+
                 case "--sarif":
                     options.Sarif = true;
                     break;
@@ -762,7 +767,7 @@ public static class CliParser
         }
 
         // If no command was specified but flags were set, default to audit
-        if (options.Command == CliCommand.None && (options.Json || options.Html || options.Markdown || options.Sarif || options.Quiet || options.ModulesFilter != null))
+        if (options.Command == CliCommand.None && (options.Json || options.Html || options.Markdown || options.Csv || options.Sarif || options.Quiet || options.ModulesFilter != null))
         {
             options.Command = CliCommand.Audit;
         }

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -370,6 +370,10 @@ public static class ConsoleFormatter
         Console.ForegroundColor = original;
         Console.WriteLine("Output results as Markdown (GitHub-flavored)");
         Console.ForegroundColor = ConsoleColor.White;
+        Console.Write("    --csv                ");
+        Console.ForegroundColor = original;
+        Console.WriteLine("Output results as CSV (one row per finding)");
+        Console.ForegroundColor = ConsoleColor.White;
         Console.Write("    -o, --output <file>  ");
         Console.ForegroundColor = original;
         Console.WriteLine("Save output to file instead of stdout");

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -113,12 +113,12 @@ static async Task<int> HandleAudit(CliOptions options)
     var engine = BuildEngine(options.ModulesFilter);
     var sw = Stopwatch.StartNew();
 
-    if (!options.Quiet && !options.Json && !options.Html && !options.Markdown && !options.Sarif)
+    if (!options.Quiet && !options.Json && !options.Html && !options.Markdown && !options.Csv && !options.Sarif)
     {
         ConsoleFormatter.PrintBanner();
     }
 
-    var progress = options.Quiet || options.Json || options.Html || options.Markdown || options.Sarif
+    var progress = options.Quiet || options.Json || options.Html || options.Markdown || options.Csv || options.Sarif
         ? null
         : new Progress<(string module, int current, int total)>(p =>
             ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
@@ -193,6 +193,20 @@ static async Task<int> HandleAudit(CliOptions options)
             var original = Console.ForegroundColor;
             Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine($"  ✓ SARIF report saved to {options.OutputFile}");
+            Console.ForegroundColor = original;
+        }
+    }
+    else if (options.Csv)
+    {
+        var generator = new ReportGenerator();
+        var csv = generator.GenerateCsvReport(report);
+        WriteOutput(csv, options.OutputFile);
+
+        if (!options.Quiet && options.OutputFile != null)
+        {
+            var original = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"  ✓ CSV report saved to {options.OutputFile}");
             Console.ForegroundColor = original;
         }
     }

--- a/src/WinSentinel.Core/Services/ReportGenerator.cs
+++ b/src/WinSentinel.Core/Services/ReportGenerator.cs
@@ -607,6 +607,69 @@ public class ReportGenerator
     }
 
     /// <summary>
+    /// Generate a CSV report with one row per finding.
+    /// Ideal for importing into Excel, Google Sheets, or data analysis tools.
+    /// </summary>
+    public string GenerateCsvReport(SecurityReport report)
+    {
+        var sb = new StringBuilder();
+
+        // Header row
+        sb.AppendLine("Module,Category,ModuleScore,ModuleGrade,Severity,Title,Description,Remediation,FixCommand,Timestamp");
+
+        foreach (var result in report.Results)
+        {
+            var modScore = SecurityScorer.CalculateCategoryScore(result);
+            var modGrade = SecurityScorer.GetGrade(modScore);
+
+            if (result.Findings.Count == 0)
+            {
+                // Still emit a row for modules with no findings so the CSV is complete
+                sb.AppendLine($"{CsvEscape(result.ModuleName)},{CsvEscape(result.Category)},{modScore},{modGrade},,No findings,,,,");
+                continue;
+            }
+
+            foreach (var finding in result.Findings.OrderByDescending(f => f.Severity).ThenBy(f => f.Title))
+            {
+                sb.Append(CsvEscape(result.ModuleName));
+                sb.Append(',');
+                sb.Append(CsvEscape(result.Category));
+                sb.Append(',');
+                sb.Append(modScore);
+                sb.Append(',');
+                sb.Append(modGrade);
+                sb.Append(',');
+                sb.Append(finding.Severity);
+                sb.Append(',');
+                sb.Append(CsvEscape(finding.Title));
+                sb.Append(',');
+                sb.Append(CsvEscape(finding.Description));
+                sb.Append(',');
+                sb.Append(CsvEscape(finding.Remediation ?? ""));
+                sb.Append(',');
+                sb.Append(CsvEscape(finding.FixCommand ?? ""));
+                sb.Append(',');
+                sb.AppendLine(finding.Timestamp.ToString("o"));
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Escape a value for CSV output (RFC 4180).
+    /// </summary>
+    private static string CsvEscape(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return "";
+        if (value.Contains('"') || value.Contains(',') || value.Contains('\n') || value.Contains('\r'))
+        {
+            return $"\"{value.Replace("\"", "\"\"")}\"";
+        }
+        return value;
+    }
+
+    /// <summary>
     /// Get an emoji representing the grade.
     /// </summary>
     private static string GetGradeEmoji(string grade) => grade switch
@@ -629,6 +692,7 @@ public class ReportGenerator
             ReportFormat.Json => GenerateJsonReport(report, trend),
             ReportFormat.Text => GenerateTextReport(report, trend),
             ReportFormat.Markdown => GenerateMarkdownReport(report, trend),
+            ReportFormat.Csv => GenerateCsvReport(report),
             _ => throw new ArgumentException($"Unknown report format: {format}", nameof(format))
         };
 
@@ -653,6 +717,7 @@ public class ReportGenerator
             ReportFormat.Json => "json",
             ReportFormat.Text => "txt",
             ReportFormat.Markdown => "md",
+            ReportFormat.Csv => "csv",
             _ => "html"
         };
         return $"WinSentinel-Report-{ts:yyyy-MM-dd-HHmm}.{extension}";
@@ -1084,5 +1149,6 @@ public enum ReportFormat
     Html,
     Json,
     Text,
-    Markdown
+    Markdown,
+    Csv
 }

--- a/tests/WinSentinel.Tests/Services/CsvReportTests.cs
+++ b/tests/WinSentinel.Tests/Services/CsvReportTests.cs
@@ -1,0 +1,98 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests.Services;
+
+public class CsvReportTests
+{
+    private static SecurityReport CreateSampleReport()
+    {
+        var result = new AuditResult
+        {
+            ModuleName = "FirewallAudit",
+            Category = "Firewall",
+            Success = true,
+        };
+        result.Findings.Add(Finding.Critical("Firewall Disabled", "Windows Firewall is off", "Firewall",
+            "Enable Windows Firewall", "netsh advfirewall set allprofiles state on"));
+        result.Findings.Add(Finding.Pass("Inbound Rules", "Inbound rules are configured", "Firewall"));
+
+        var report = new SecurityReport
+        {
+            SecurityScore = 65,
+            GeneratedAt = DateTimeOffset.UtcNow,
+        };
+        report.Results.Add(result);
+        return report;
+    }
+
+    [Fact]
+    public void GenerateCsvReport_ContainsHeader()
+    {
+        var generator = new ReportGenerator();
+        var csv = generator.GenerateCsvReport(CreateSampleReport());
+
+        Assert.StartsWith("Module,Category,ModuleScore,ModuleGrade,Severity,Title,Description,Remediation,FixCommand,Timestamp", csv);
+    }
+
+    [Fact]
+    public void GenerateCsvReport_ContainsFindings()
+    {
+        var generator = new ReportGenerator();
+        var csv = generator.GenerateCsvReport(CreateSampleReport());
+
+        Assert.Contains("Firewall Disabled", csv);
+        Assert.Contains("Inbound Rules", csv);
+        Assert.Contains("Critical", csv);
+        Assert.Contains("Pass", csv);
+    }
+
+    [Fact]
+    public void GenerateCsvReport_EscapesCommasAndQuotes()
+    {
+        var result = new AuditResult
+        {
+            ModuleName = "TestModule",
+            Category = "Test",
+            Success = true,
+        };
+        result.Findings.Add(Finding.Warning("Title, with comma", "Desc with \"quotes\"", "Test"));
+
+        var report = new SecurityReport { SecurityScore = 80 };
+        report.Results.Add(result);
+
+        var generator = new ReportGenerator();
+        var csv = generator.GenerateCsvReport(report);
+
+        Assert.Contains("\"Title, with comma\"", csv);
+        Assert.Contains("\"Desc with \"\"quotes\"\"\"", csv);
+    }
+
+    [Fact]
+    public void GenerateCsvReport_EmptyModule_StillEmitsRow()
+    {
+        var result = new AuditResult
+        {
+            ModuleName = "EmptyModule",
+            Category = "Empty",
+            Success = true,
+        };
+
+        var report = new SecurityReport { SecurityScore = 100 };
+        report.Results.Add(result);
+
+        var generator = new ReportGenerator();
+        var csv = generator.GenerateCsvReport(report);
+
+        Assert.Contains("EmptyModule", csv);
+        Assert.Contains("No findings", csv);
+    }
+
+    [Fact]
+    public void ReportFormat_Csv_GeneratesCorrectFilename()
+    {
+        var filename = ReportGenerator.GenerateFilename(ReportFormat.Csv);
+        Assert.EndsWith(".csv", filename);
+        Assert.StartsWith("WinSentinel-Report-", filename);
+    }
+}


### PR DESCRIPTION
## Summary
Adds \--csv\ flag to export audit findings as CSV (RFC 4180 compliant).

## Usage
\\\ash
winsentinel --audit --csv                    # Output CSV to stdout
winsentinel --audit --csv -o findings.csv    # Save to file
\\\

## Output format
One row per finding with columns: Module, Category, ModuleScore, ModuleGrade, Severity, Title, Description, Remediation, FixCommand, Timestamp

Modules with no findings still get a placeholder row for completeness.

## Changes
- \ReportGenerator.GenerateCsvReport()\ with RFC 4180 escaping
- \ReportFormat.Csv\ enum value
- \--csv\ CLI flag + handler
- Help text updated
- 5 unit tests (header, findings, escaping, empty modules, filename)