### PR TITLE
fix: make BruteForceChain correlation rule bidirectional

### DIFF
--- a/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
+++ b/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
@@ -273,6 +273,30 @@ public class ThreatCorrelator
                 });
             }
         }
+
+        // Reverse: escalation/account creation arrives after brute force is already in window
+        if (newEvent.Title.Contains("Privilege", StringComparison.OrdinalIgnoreCase) ||
+            newEvent.Title.Contains("Account Created", StringComparison.OrdinalIgnoreCase) ||
+            newEvent.Title.Contains("Kill Chain", StringComparison.OrdinalIgnoreCase))
+        {
+            var bruteForce = window.FirstOrDefault(e =>
+                e.Source == "EventLogMonitor" &&
+                e.Id != newEvent.Id &&
+                e.Title.Contains("Brute Force", StringComparison.OrdinalIgnoreCase));
+
+            if (bruteForce != null && !IsRecentCorrelation("BruteForceChain", $"rev-{newEvent.Id}"))
+            {
+                results.Add(new CorrelatedThreat
+                {
+                    ContributingEvents = { bruteForce, newEvent },
+                    CombinedSeverity = ThreatSeverity.Critical,
+                    RuleName = "BruteForceChain",
+                    ChainDescription = $"{newEvent.Title} detected following brute force activity. " +
+                                       $"An attacker may have successfully breached and is escalating privileges.",
+                    ThreatScore = CalculateChainScore(bruteForce, newEvent) + 40
+                });
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

The \CheckBruteForceChain\ correlation rule only fired when the brute force event was the *newly arriving* event. If a privilege escalation or account creation event arrived after the brute force was already in the correlation window, no correlation was detected.

This is inconsistent with the other correlation rules (\CheckProcessPlusDll\, \CheckDefenderPlusUnsigned\, \CheckHostsFileAndProcess\) which all check both directions.

## Fix

Added a reverse check: when a privilege escalation, account creation, or kill chain event arrives, we now also look for existing brute force events in the window and emit a correlation.

Each direction uses a distinct cooldown key (\ev-{id}\) to prevent duplicate correlations.

## Impact

Previously missed attack chains where brute force was detected first, followed by privilege escalation. This is actually the more common real-world sequence — attackers brute force credentials, then escalate.