### PR TITLE
fix: CalculateMedian returns double to avoid integer division truncation

### DIFF
--- a/src/WinSentinel.Core/Services/TrendAnalyzer.cs
+++ b/src/WinSentinel.Core/Services/TrendAnalyzer.cs
@@ -193,12 +193,12 @@ public class TrendAnalyzer
         return Math.Sqrt(variance);
     }
 
-    private static int CalculateMedian(List<int> values)
+    private static double CalculateMedian(List<int> values)
     {
         var sorted = values.OrderBy(v => v).ToList();
         var mid = sorted.Count / 2;
         return sorted.Count % 2 == 0
-            ? (sorted[mid - 1] + sorted[mid]) / 2
+            ? (sorted[mid - 1] + sorted[mid]) / 2.0
             : sorted[mid];
     }
 
@@ -301,7 +301,7 @@ public class TrendReport
 
     // Statistics
     public double AverageScore { get; set; }
-    public int MedianScore { get; set; }
+    public double MedianScore { get; set; }
     public int MinScore { get; set; }
     public int MaxScore { get; set; }
     public double ScoreStdDev { get; set; }

--- a/tests/WinSentinel.Tests/Services/TrendAnalyzerTests.cs
+++ b/tests/WinSentinel.Tests/Services/TrendAnalyzerTests.cs
@@ -85,7 +85,25 @@ public class TrendAnalyzerTests
         var runs = CreateRuns((50, "D", 5), (60, "C", 3), (70, "C", 1), (80, "B", 0));
         var report = _analyzer.Analyze(runs);
 
-        Assert.Equal(65, report.MedianScore); // (60+70)/2
+        Assert.Equal(65.0, report.MedianScore); // (60+70)/2
+    }
+
+    [Fact]
+    public void Analyze_CalculatesMedian_EvenCount_FractionalResult()
+    {
+        var runs = CreateRuns((70, "C", 3), (75, "C+", 1), (80, "B", 0));
+        var report = _analyzer.Analyze(runs);
+
+        Assert.Equal(75, report.MedianScore); // odd count, exact middle
+    }
+
+    [Fact]
+    public void Analyze_CalculatesMedian_EvenCount_NonInteger()
+    {
+        var runs = CreateRuns((50, "D", 5), (60, "C", 3), (71, "C", 1), (80, "B", 0));
+        var report = _analyzer.Analyze(runs);
+
+        Assert.Equal(65.5, report.MedianScore); // (60+71)/2 = 65.5
     }
 
     [Fact]


### PR DESCRIPTION
Changes MedianScore from int to double and CalculateMedian to use floating-point division (/ 2.0) for even-count lists. Previously, median of [70, 75] would return 72 instead of 72.5.

Adds tests for fractional median results.

Fixes #35