### PR TITLE
fix: ExtractDirectory truncates paths at dot characters

### DIFF
--- a/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
+++ b/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
@@ -417,7 +417,7 @@ public class ThreatCorrelator
             while (pathStart < description.Length && description[pathStart] == ' ')
                 pathStart++;
 
-            var pathEnd = description.IndexOfAny(new[] { '\n', '\r', '.', ',' }, pathStart);
+            var pathEnd = description.IndexOfAny(new[] { '\n', '\r', ',' }, pathStart);
             if (pathEnd < 0) pathEnd = description.Length;
 
             var fullPath = description[pathStart..pathEnd].Trim();

--- a/tests/WinSentinel.Tests/Agent/ThreatCorrelatorTests.cs
+++ b/tests/WinSentinel.Tests/Agent/ThreatCorrelatorTests.cs
@@ -238,6 +238,14 @@ public class ThreatCorrelatorTests
         Assert.Null(dir);
     }
 
+    [Fact]
+    public void ExtractDirectory_DottedDirectoryName_ParsesCorrectly()
+    {
+        // Regression: '.' in directory names (e.g. user.name) must not truncate the path
+        var dir = ThreatCorrelator.ExtractDirectory("Alert. Path: C:\\Users\\john.doe\\AppData\\Local\\malware.exe");
+        Assert.Equal(@"C:\Users\john.doe\AppData\Local", dir);
+    }
+
     [Theory]
     [InlineData(ThreatSeverity.Critical, 40)]
     [InlineData(ThreatSeverity.High, 25)]


### PR DESCRIPTION
## Bug
\ExtractDirectory\ in \ThreatCorrelator\ used \'.'}\ as a path delimiter in \IndexOfAny\, causing paths with dots in directory names to be truncated.

**Example:** \Path: C:\Users\john.doe\AppData\Local\malware.exe\ would extract as \C:\Users\john\ instead of \C:\Users\john.doe\AppData\Local\.

This broke DLL sideloading correlation (Rule 1) for any user with a dotted username or paths through directories containing dots.

## Fix
Removed \'.'\ from the delimiter array. Paths are now correctly parsed to the next newline or comma.

## Testing
All 16 ThreatCorrelator tests pass, including new regression test for dotted directory names.