### PR TITLE
feat(cli): add --watch live monitoring mode

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -48,6 +48,10 @@ public class CliOptions
     public string? TimelineSeverityFilter { get; set; }
     public int? TimelineMaxEvents { get; set; }
     public string? TimelineModuleFilter { get; set; }
+    public bool Watch { get; set; }
+    public int WatchIntervalSeconds { get; set; } = 300;
+    public bool WatchCompact { get; set; }
+    public bool WatchBeep { get; set; }
     public FindingAgeAction AgeAction { get; set; } = FindingAgeAction.None;
     public string? AgeSeverityFilter { get; set; }
     public string? AgeModuleFilter { get; set; }
@@ -71,6 +75,7 @@ public enum CliCommand
     Badge,
     Timeline,
     FindingAge,
+    Watch,
     Help,
     Version
 }
@@ -323,6 +328,39 @@ public static class CliParser
                         options.Error = "Missing value for --timeline-module.";
                         return options;
                     }
+                    break;
+
+                case "--watch" or "-w":
+                    options.Command = CliCommand.Watch;
+                    options.Watch = true;
+                    break;
+
+                case "--watch-interval":
+                    if (i + 1 < args.Length)
+                    {
+                        if (int.TryParse(args[++i], out int interval) && interval >= 10 && interval <= 86400)
+                        {
+                            options.WatchIntervalSeconds = interval;
+                        }
+                        else
+                        {
+                            options.Error = "Invalid watch-interval value. Must be 10-86400 seconds.";
+                            return options;
+                        }
+                    }
+                    else
+                    {
+                        options.Error = "Missing value for --watch-interval (seconds).";
+                        return options;
+                    }
+                    break;
+
+                case "--watch-compact":
+                    options.WatchCompact = true;
+                    break;
+
+                case "--watch-beep":
+                    options.WatchBeep = true;
                     break;
 
                 case "--badge":

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -1710,4 +1710,222 @@ public static partial class ConsoleFormatter
         Console.WriteLine();
     }
 
+    // ── Watch Mode Formatting ────────────────────────────────────────
+
+    /// <summary>
+    /// Print the watch mode banner.
+    /// </summary>
+    public static void PrintWatchBanner(int intervalSeconds, string? moduleFilter)
+    {
+        var original = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine();
+        Console.WriteLine("  ╔══════════════════════════════════════════════╗");
+        Console.WriteLine("  ║      🛡️  WinSentinel Watch Mode             ║");
+        Console.WriteLine("  ╚══════════════════════════════════════════════╝");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write($"  Interval: {FormatInterval(intervalSeconds)}");
+        if (!string.IsNullOrEmpty(moduleFilter))
+            Console.Write($" │ Modules: {moduleFilter}");
+        Console.WriteLine(" │ Press Ctrl+C to stop");
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  ─────┬────────┬───────┬──────────┬──────────┬──────────────");
+        Console.Write("  Scan │ Score  │ Grade │ Critical │ Warnings │ Changes");
+        Console.WriteLine();
+        Console.WriteLine("  ─────┼────────┼───────┼──────────┼──────────┼──────────────");
+        Console.ForegroundColor = original;
+    }
+
+    /// <summary>
+    /// Print a compact one-line watch result.
+    /// </summary>
+    public static void PrintWatchLineCompact(int scanNumber, int score, int critical, int warnings,
+        int? scoreDelta, int? criticalDelta, int? warningDelta, TimeSpan elapsed)
+    {
+        var original = Console.ForegroundColor;
+        var grade = SecurityScorer.GetGrade(score);
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write($"  {scanNumber,4} │ ");
+
+        Console.ForegroundColor = GetScoreColor(score);
+        Console.Write($"{score,4}/100");
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write(" │ ");
+
+        Console.ForegroundColor = GetScoreColor(score);
+        Console.Write($"  {grade}  ");
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write(" │ ");
+
+        Console.ForegroundColor = critical > 0 ? ConsoleColor.Red : ConsoleColor.Green;
+        Console.Write($"   {critical,3}   ");
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write(" │ ");
+
+        Console.ForegroundColor = warnings > 0 ? ConsoleColor.Yellow : ConsoleColor.Green;
+        Console.Write($"   {warnings,3}   ");
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write(" │ ");
+
+        if (scoreDelta.HasValue)
+        {
+            PrintDelta("S", scoreDelta.Value, invert: false);
+            Console.Write(" ");
+            PrintDelta("C", criticalDelta ?? 0, invert: true);
+            Console.Write(" ");
+            PrintDelta("W", warningDelta ?? 0, invert: true);
+        }
+        else
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write("  baseline");
+        }
+
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Print a full watch scan result block (non-compact).
+    /// </summary>
+    public static void PrintWatchScanResult(int scanNumber, SecurityReport report,
+        int? scoreDelta, int? criticalDelta, int? warningDelta, TimeSpan elapsed)
+    {
+        var original = Console.ForegroundColor;
+        var score = report.SecurityScore;
+        var grade = SecurityScorer.GetGrade(score);
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write($"  ── Scan #{scanNumber}");
+        Console.Write($" at {DateTimeOffset.Now:HH:mm:ss}");
+        Console.Write($" ({elapsed.TotalSeconds:F1}s)");
+        Console.WriteLine(" ──");
+
+        Console.Write("  Score: ");
+        Console.ForegroundColor = GetScoreColor(score);
+        Console.Write($"{score}/100 ({grade})");
+
+        if (scoreDelta.HasValue && scoreDelta.Value != 0)
+        {
+            Console.Write(" ");
+            Console.ForegroundColor = scoreDelta.Value > 0 ? ConsoleColor.Green : ConsoleColor.Red;
+            Console.Write(scoreDelta.Value > 0 ? $"▲+{scoreDelta.Value}" : $"▼{scoreDelta.Value}");
+        }
+        Console.WriteLine();
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write("  ");
+        Console.ForegroundColor = report.TotalCritical > 0 ? ConsoleColor.Red : ConsoleColor.DarkGray;
+        Console.Write($"{report.TotalCritical} critical");
+        if (criticalDelta.HasValue && criticalDelta.Value != 0)
+        {
+            Console.ForegroundColor = criticalDelta.Value > 0 ? ConsoleColor.Red : ConsoleColor.Green;
+            Console.Write(criticalDelta.Value > 0 ? $" (+{criticalDelta.Value})" : $" ({criticalDelta.Value})");
+        }
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write(" · ");
+
+        Console.ForegroundColor = report.TotalWarnings > 0 ? ConsoleColor.Yellow : ConsoleColor.DarkGray;
+        Console.Write($"{report.TotalWarnings} warnings");
+        if (warningDelta.HasValue && warningDelta.Value != 0)
+        {
+            Console.ForegroundColor = warningDelta.Value > 0 ? ConsoleColor.Yellow : ConsoleColor.Green;
+            Console.Write(warningDelta.Value > 0 ? $" (+{warningDelta.Value})" : $" ({warningDelta.Value})");
+        }
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write($" · {report.TotalFindings} total");
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+
+        var problemModules = report.Results
+            .Where(r => r.Findings.Any(f => f.Severity is Severity.Critical or Severity.Warning))
+            .OrderBy(r => SecurityScorer.CalculateCategoryScore(r))
+            .Take(5)
+            .ToList();
+
+        if (problemModules.Count > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write("  Hotspots: ");
+            for (int i = 0; i < problemModules.Count; i++)
+            {
+                var m = problemModules[i];
+                var mScore = SecurityScorer.CalculateCategoryScore(m);
+                Console.ForegroundColor = GetScoreColor(mScore);
+                Console.Write($"{m.Category}({mScore})");
+                if (i < problemModules.Count - 1)
+                {
+                    Console.ForegroundColor = ConsoleColor.DarkGray;
+                    Console.Write(", ");
+                }
+            }
+            Console.ForegroundColor = original;
+            Console.WriteLine();
+        }
+
+        Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Print countdown timer between scans.
+    /// </summary>
+    public static void PrintWatchCountdown(int totalSeconds, CancellationToken ct)
+    {
+        var original = Console.ForegroundColor;
+        for (int remaining = totalSeconds; remaining > 0; remaining--)
+        {
+            if (ct.IsCancellationRequested) break;
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write($"\r  Next scan in {remaining}s...  ");
+            Console.ForegroundColor = original;
+            try { Task.Delay(1000, ct).GetAwaiter().GetResult(); } catch (TaskCanceledException) { break; }
+        }
+        Console.Write("\r" + new string(' ', 40) + "\r");
+    }
+
+    /// <summary>
+    /// Print watch mode stopped summary.
+    /// </summary>
+    public static void PrintWatchStopped(int totalScans, TimeSpan totalElapsed)
+    {
+        var original = Console.ForegroundColor;
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.Write("  ■ Watch stopped");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine($" — {totalScans} scans over {FormatInterval((int)totalElapsed.TotalSeconds)}");
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+    }
+
+    private static void PrintDelta(string label, int delta, bool invert)
+    {
+        if (delta == 0)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write($"{label}=");
+            return;
+        }
+
+        bool isBad = invert ? delta > 0 : delta < 0;
+        Console.ForegroundColor = isBad ? ConsoleColor.Red : ConsoleColor.Green;
+        Console.Write(delta > 0 ? $"{label}+{delta}" : $"{label}{delta}");
+    }
+
+    private static string FormatInterval(int seconds)
+    {
+        if (seconds < 60) return $"{seconds}s";
+        if (seconds < 3600) return $"{seconds / 60}m {seconds % 60}s";
+        return $"{seconds / 3600}h {seconds % 3600 / 60}m";
+    }
+
 }

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -32,8 +32,132 @@ return options.Command switch
     CliCommand.Trend => HandleTrend(options),
     CliCommand.Timeline => HandleTimeline(options),
     CliCommand.FindingAge => HandleFindingAge(options),
+    CliCommand.Watch => await HandleWatch(options),
     _ => HandleHelp()
 };
+
+// ── Watch Mode ────────────────────────────────────────────────────────
+
+static async Task<int> HandleWatch(CliOptions options)
+{
+    var cts = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, e) =>
+    {
+        e.Cancel = true;
+        cts.Cancel();
+    };
+
+    int? previousScore = null;
+    int? previousCritical = null;
+    int? previousWarnings = null;
+    var scanCount = 0;
+    var startTime = DateTimeOffset.Now;
+
+    if (!options.Quiet)
+    {
+        Console.Clear();
+        ConsoleFormatter.PrintWatchBanner(options.WatchIntervalSeconds, options.ModulesFilter);
+    }
+
+    while (!cts.Token.IsCancellationRequested)
+    {
+        scanCount++;
+        var engine = BuildEngine(options.ModulesFilter);
+        var sw = Stopwatch.StartNew();
+
+        SecurityReport report;
+        try
+        {
+            report = await engine.RunFullAuditAsync(null);
+        }
+        catch (Exception ex)
+        {
+            if (!options.Quiet)
+            {
+                var c = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"  ✗ Scan #{scanCount} failed: {ex.Message}");
+                Console.ForegroundColor = c;
+            }
+            try { await Task.Delay(options.WatchIntervalSeconds * 1000, cts.Token); } catch (TaskCanceledException) { break; }
+            continue;
+        }
+
+        sw.Stop();
+
+        var currentScore = report.SecurityScore;
+        var currentCritical = report.TotalCritical;
+        var currentWarnings = report.TotalWarnings;
+
+        // Detect changes
+        int? scoreDelta = previousScore.HasValue ? currentScore - previousScore.Value : null;
+        int? criticalDelta = previousCritical.HasValue ? currentCritical - previousCritical.Value : null;
+        int? warningDelta = previousWarnings.HasValue ? currentWarnings - previousWarnings.Value : null;
+
+        bool isRegression = scoreDelta < 0 || criticalDelta > 0;
+
+        if (options.Json)
+        {
+            var jsonResult = new
+            {
+                scan = scanCount,
+                timestamp = DateTimeOffset.Now,
+                score = currentScore,
+                grade = SecurityScorer.GetGrade(currentScore),
+                critical = currentCritical,
+                warnings = currentWarnings,
+                totalFindings = report.TotalFindings,
+                scanDuration = sw.Elapsed.TotalSeconds,
+                delta = new
+                {
+                    score = scoreDelta,
+                    critical = criticalDelta,
+                    warnings = warningDelta
+                },
+                isRegression
+            };
+            var jsonOptions = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+            Console.WriteLine(JsonSerializer.Serialize(jsonResult, jsonOptions));
+        }
+        else if (options.WatchCompact)
+        {
+            ConsoleFormatter.PrintWatchLineCompact(scanCount, currentScore, currentCritical, currentWarnings,
+                scoreDelta, criticalDelta, warningDelta, sw.Elapsed);
+        }
+        else
+        {
+            ConsoleFormatter.PrintWatchScanResult(scanCount, report, scoreDelta, criticalDelta, warningDelta, sw.Elapsed);
+        }
+
+        // Beep on regression
+        if (options.WatchBeep && isRegression)
+        {
+            Console.Beep();
+        }
+
+        previousScore = currentScore;
+        previousCritical = currentCritical;
+        previousWarnings = currentWarnings;
+
+        // Countdown
+        if (!options.Quiet && !options.Json)
+        {
+            ConsoleFormatter.PrintWatchCountdown(options.WatchIntervalSeconds, cts.Token);
+        }
+        else
+        {
+            try { await Task.Delay(options.WatchIntervalSeconds * 1000, cts.Token); } catch (TaskCanceledException) { break; }
+        }
+    }
+
+    if (!options.Quiet && !options.Json)
+    {
+        var elapsed = DateTimeOffset.Now - startTime;
+        ConsoleFormatter.PrintWatchStopped(scanCount, elapsed);
+    }
+
+    return 0;
+}
 
 // ── Command Handlers ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds a **\--watch\ live monitoring mode** for continuous security posture monitoring directly in the terminal.

## Usage

\\\ash
winsentinel --watch                         # scan every 5 min (default)
winsentinel --watch --watch-interval 60     # scan every 60s
winsentinel --watch --watch-compact         # one-line-per-scan table view
winsentinel --watch --watch-beep            # beep on regressions
winsentinel --watch --json                  # JSON output per scan
winsentinel --watch -m firewall,network     # watch specific modules
\\\

## Features

- **Continuous scanning** with configurable interval (10s – 24h)
- **Change detection** — score deltas, critical/warning count changes between scans
- **Compact table mode** (\--watch-compact\) for dense monitoring
- **Full mode** with module hotspot breakdown (worst-scoring modules)
- **Audible alerts** (\--watch-beep\) on security regressions
- **JSON output** for piping to monitoring tools/dashboards
- **Module filtering** — watch only specific audit modules
- **Graceful Ctrl+C shutdown** with session summary

## Files Changed

- \src/WinSentinel.Cli/CliParser.cs\ — new \Watch\ command + CLI arg parsing
- \src/WinSentinel.Cli/Program.cs\ — \HandleWatch\ async scan loop
- \src/WinSentinel.Cli/ConsoleFormatter.cs\ — watch display (banner, compact line, full result, countdown, stopped)