### PR TITLE
feat: add --digest command for executive security summary

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -64,6 +64,8 @@ public class CliOptions
     public ExemptionAction ExemptionAction { get; set; } = ExemptionAction.None;
     public int ExemptionWarningDays { get; set; } = 7;
     public int ExemptionStaleDays { get; set; } = 90;
+    public int DigestTrendDays { get; set; } = 30;
+    public bool DigestNoTrend { get; set; }
 }
 
 public enum CliCommand
@@ -85,6 +87,7 @@ public enum CliCommand
     Harden,
     Policy,
     Exemptions,
+    Digest,
     Help,
     Version
 }
@@ -216,6 +219,34 @@ public static class CliParser
 
                 case "--harden":
                     options.Command = CliCommand.Harden;
+                    break;
+
+                case "--digest" or "-d":
+                    options.Command = CliCommand.Digest;
+                    break;
+
+                case "--digest-days":
+                    if (i + 1 < args.Length)
+                    {
+                        if (int.TryParse(args[++i], out int digestDays) && digestDays >= 1 && digestDays <= 365)
+                        {
+                            options.DigestTrendDays = digestDays;
+                        }
+                        else
+                        {
+                            options.Error = "Invalid digest-days value. Must be 1-365.";
+                            return options;
+                        }
+                    }
+                    else
+                    {
+                        options.Error = "Missing value for --digest-days.";
+                        return options;
+                    }
+                    break;
+
+                case "--no-trend":
+                    options.DigestNoTrend = true;
                     break;
 
                 case "--policy":

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -360,6 +360,10 @@ public static partial class ConsoleFormatter
         Console.ForegroundColor = original;
         Console.WriteLine("Security Policy as Code (export/import/validate/diff)");
         Console.ForegroundColor = ConsoleColor.White;
+        Console.Write("    --digest, -d         ");
+        Console.ForegroundColor = original;
+        Console.WriteLine("Executive security digest (score, risks, trend, next steps)");
+        Console.ForegroundColor = ConsoleColor.White;
         Console.Write("    --help, -h           ");
         Console.ForegroundColor = original;
         Console.WriteLine("Show this help message");

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -36,6 +36,7 @@ return options.Command switch
     CliCommand.Harden => await HandleHarden(options),
     CliCommand.Policy => HandlePolicy(options),
     CliCommand.Exemptions => HandleExemptions(options),
+    CliCommand.Digest => await HandleDigest(options),
     _ => HandleHelp()
 };
 
@@ -114,6 +115,243 @@ static async Task<int> HandleHarden(CliOptions options)
     }
 
     return 0;
+}
+
+// ── Security Digest ──────────────────────────────────────────────────
+
+static async Task<int> HandleDigest(CliOptions options)
+{
+    var engine = BuildEngine(options.ModulesFilter);
+    var sw = Stopwatch.StartNew();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintBanner();
+        Console.WriteLine("  Generating security digest...");
+        Console.WriteLine();
+    }
+
+    var progress = options.Quiet || options.Json
+        ? null
+        : new Progress<(string module, int current, int total)>(p =>
+            ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
+
+    var report = await engine.RunFullAuditAsync(progress);
+    sw.Stop();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintProgressDone(engine.Modules.Count, sw.Elapsed);
+    }
+
+    // Load history for trend data
+    List<AuditRunRecord>? history = null;
+    if (!options.DigestNoTrend)
+    {
+        using var historyService = new AuditHistoryService();
+        historyService.EnsureDatabase();
+        history = historyService.GetHistory(options.DigestTrendDays);
+    }
+
+    var digestService = new SecurityDigestService();
+    var digest = digestService.Generate(report, history);
+
+    if (options.Json)
+    {
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() },
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        };
+        var json = JsonSerializer.Serialize(digest, jsonOptions);
+        WriteOutput(json, options.OutputFile);
+    }
+    else
+    {
+        PrintDigestConsole(digest, options.Quiet);
+    }
+
+    return DetermineExitCode(report, options.Threshold);
+}
+
+static void PrintDigestConsole(SecurityDigest digest, bool quiet)
+{
+    var orig = Console.ForegroundColor;
+
+    if (!quiet)
+    {
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("  ╔══════════════════════════════════════════════╗");
+        Console.WriteLine("  ║       🛡️  Security Digest                   ║");
+        Console.WriteLine("  ╚══════════════════════════════════════════════╝");
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+    }
+
+    // Score + Grade
+    var scoreColor = digest.Score switch
+    {
+        >= 80 => ConsoleColor.Green,
+        >= 60 => ConsoleColor.Yellow,
+        _ => ConsoleColor.Red
+    };
+
+    Console.Write("  Score: ");
+    Console.ForegroundColor = scoreColor;
+    Console.Write($"{digest.Score}/100 ({digest.Grade})");
+    Console.ForegroundColor = orig;
+
+    // Trend indicator inline
+    if (digest.Trend != null)
+    {
+        var trendColor = digest.Trend.Direction == "Improving" ? ConsoleColor.Green
+                       : digest.Trend.Direction == "Declining" ? ConsoleColor.Red
+                       : ConsoleColor.DarkGray;
+        var arrow = digest.Trend.Direction == "Improving" ? "↑"
+                  : digest.Trend.Direction == "Declining" ? "↓"
+                  : "→";
+        Console.Write("  ");
+        Console.ForegroundColor = trendColor;
+        Console.Write($"{arrow} {(digest.Trend.ScoreChange >= 0 ? "+" : "")}{digest.Trend.ScoreChange}");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write($" (avg: {digest.Trend.AverageScore}, {digest.Trend.TotalScans} scans)");
+    }
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    // Findings summary line
+    Console.Write("  Findings: ");
+    if (digest.CriticalCount > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.Write($"{digest.CriticalCount} critical");
+        Console.ForegroundColor = orig;
+        Console.Write("  ");
+    }
+    if (digest.WarningCount > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Write($"{digest.WarningCount} warnings");
+        Console.ForegroundColor = orig;
+        Console.Write("  ");
+    }
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.Write($"{digest.InfoCount} info  {digest.PassCount} pass");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    // Assessment
+    Console.Write("  Status: ");
+    Console.ForegroundColor = digest.CriticalCount > 0 ? ConsoleColor.Red
+                            : digest.Score >= 80 ? ConsoleColor.Green
+                            : ConsoleColor.Yellow;
+    Console.WriteLine(digest.Assessment);
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    // Top Risks
+    if (digest.TopRisks.Count > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine("  TOP RISKS");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  ──────────────────────────────────────────");
+        Console.ForegroundColor = orig;
+
+        foreach (var risk in digest.TopRisks)
+        {
+            var sColor = risk.Severity == Severity.Critical ? ConsoleColor.Red : ConsoleColor.Yellow;
+            Console.ForegroundColor = sColor;
+            Console.Write($"  [{risk.Severity}] ");
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.Write(risk.Title);
+            if (risk.HasAutoFix)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.Write(" [auto-fix]");
+            }
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+
+            if (risk.Remediation != null)
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine($"    → {risk.Remediation}");
+                Console.ForegroundColor = orig;
+            }
+        }
+        Console.WriteLine();
+    }
+
+    // Module Heat Map (compact)
+    Console.ForegroundColor = ConsoleColor.White;
+    Console.WriteLine("  MODULE SCORES");
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.WriteLine("  ──────────────────────────────────────────");
+    Console.ForegroundColor = orig;
+
+    foreach (var mod in digest.ModuleBreakdown)
+    {
+        var mColor = mod.Score switch
+        {
+            >= 80 => ConsoleColor.Green,
+            >= 60 => ConsoleColor.Yellow,
+            _ => ConsoleColor.Red
+        };
+
+        Console.Write("  ");
+        Console.ForegroundColor = mColor;
+
+        // Mini bar
+        int barLen = mod.Score / 5;
+        Console.Write(new string('█', barLen));
+        Console.Write(new string('░', 20 - barLen));
+
+        Console.Write($" {mod.Score,3}/100");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write($"  {mod.Name}");
+
+        if (mod.Critical > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Write($"  ({mod.Critical}C)");
+        }
+        else if (mod.Warnings > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.Write($"  ({mod.Warnings}W)");
+        }
+
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+    }
+    Console.WriteLine();
+
+    // Next Steps
+    if (digest.NextSteps.Count > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine("  NEXT STEPS");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  ──────────────────────────────────────────");
+        Console.ForegroundColor = orig;
+
+        for (int i = 0; i < digest.NextSteps.Count; i++)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.Write($"  {i + 1}. ");
+            Console.ForegroundColor = orig;
+            Console.WriteLine(digest.NextSteps[i]);
+        }
+        Console.WriteLine();
+    }
+
+    // Footer
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.WriteLine($"  {digest.MachineName} | {digest.GeneratedAt.LocalDateTime:g}");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
 }
 
 // ── Status Dashboard ─────────────────────────────────────────────────

--- a/src/WinSentinel.Core/Services/SecurityDigestService.cs
+++ b/src/WinSentinel.Core/Services/SecurityDigestService.cs
@@ -1,0 +1,228 @@
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+/// <summary>
+/// Generates a concise executive security digest combining current audit results,
+/// trend data, top risks, and prioritized next steps into a single report.
+/// </summary>
+public class SecurityDigestService
+{
+    /// <summary>
+    /// Generate a digest from current audit results and optional historical data.
+    /// </summary>
+    public SecurityDigest Generate(SecurityReport report, List<AuditRunRecord>? history = null)
+    {
+        var digest = new SecurityDigest
+        {
+            GeneratedAt = DateTimeOffset.Now,
+            MachineName = Environment.MachineName,
+            Score = report.SecurityScore,
+            Grade = SecurityScorer.GetGrade(report.SecurityScore),
+            TotalFindings = report.TotalFindings,
+            CriticalCount = report.TotalCritical,
+            WarningCount = report.TotalWarnings,
+            InfoCount = report.TotalInfo,
+            PassCount = report.TotalPass,
+        };
+
+        // Top risks: critical first, then warnings, limited to 5
+        var topFindings = report.Results
+            .SelectMany(r => r.Findings.Select(f => new DigestFinding
+            {
+                Title = f.Title,
+                Severity = f.Severity,
+                Category = f.Category,
+                Remediation = f.Remediation,
+                HasAutoFix = !string.IsNullOrWhiteSpace(f.FixCommand)
+            }))
+            .Where(f => f.Severity is Severity.Critical or Severity.Warning)
+            .OrderByDescending(f => f.Severity)
+            .ThenBy(f => f.Title)
+            .Take(5)
+            .ToList();
+
+        digest.TopRisks = topFindings;
+
+        // Module breakdown: worst-scoring modules first
+        digest.ModuleBreakdown = report.Results
+            .Select(r => new DigestModule
+            {
+                Name = r.Category,
+                Score = SecurityScorer.CalculateCategoryScore(r),
+                Critical = r.CriticalCount,
+                Warnings = r.WarningCount,
+                Status = r.CriticalCount > 0 ? "Critical"
+                       : r.WarningCount > 0 ? "Warning"
+                       : "Good"
+            })
+            .OrderBy(m => m.Score)
+            .ToList();
+
+        // Trend data if history available
+        if (history != null && history.Count >= 2)
+        {
+            var chronological = history.OrderBy(r => r.Timestamp).ToList();
+            var latest = chronological.Last();
+            var previous = chronological[^2];
+
+            digest.Trend = new DigestTrend
+            {
+                PreviousScore = previous.OverallScore,
+                ScoreChange = latest.OverallScore - previous.OverallScore,
+                Direction = latest.OverallScore > previous.OverallScore ? "Improving"
+                          : latest.OverallScore < previous.OverallScore ? "Declining"
+                          : "Stable",
+                TotalScans = chronological.Count,
+                BestScore = chronological.Max(r => r.OverallScore),
+                WorstScore = chronological.Min(r => r.OverallScore),
+                AverageScore = (int)Math.Round(chronological.Average(r => (double)r.OverallScore)),
+                FirstScanDate = chronological.First().Timestamp,
+                LastScanDate = latest.Timestamp,
+            };
+
+            // Calculate streak
+            int streak = 0;
+            for (int i = chronological.Count - 1; i >= 1; i--)
+            {
+                var diff = chronological[i].OverallScore - chronological[i - 1].OverallScore;
+                if (digest.Trend.ScoreChange > 0 && diff > 0) streak++;
+                else if (digest.Trend.ScoreChange < 0 && diff < 0) streak++;
+                else if (digest.Trend.ScoreChange == 0 && diff == 0) streak++;
+                else break;
+            }
+            digest.Trend.Streak = streak;
+        }
+
+        // Generate actionable next steps
+        digest.NextSteps = GenerateNextSteps(report, digest);
+
+        // Overall assessment
+        digest.Assessment = GenerateAssessment(digest);
+
+        return digest;
+    }
+
+    private List<string> GenerateNextSteps(SecurityReport report, SecurityDigest digest)
+    {
+        var steps = new List<string>();
+
+        // Count auto-fixable
+        var autoFixable = report.Results
+            .SelectMany(r => r.Findings)
+            .Count(f => f.Severity is Severity.Critical or Severity.Warning
+                     && !string.IsNullOrWhiteSpace(f.FixCommand));
+
+        if (digest.CriticalCount > 0)
+        {
+            steps.Add($"Address {digest.CriticalCount} critical finding(s) immediately — run `winsentinel --fix-all` to auto-fix {autoFixable} issue(s)");
+        }
+        else if (autoFixable > 0)
+        {
+            steps.Add($"Run `winsentinel --fix-all` to auto-fix {autoFixable} warning(s)");
+        }
+
+        // Worst module suggestion
+        var worstModule = digest.ModuleBreakdown.FirstOrDefault(m => m.Score < 80);
+        if (worstModule != null)
+        {
+            steps.Add($"Focus on {worstModule.Name} (score: {worstModule.Score}/100) — run `winsentinel --audit -m {worstModule.Name.ToLowerInvariant().Replace(" ", "")}` for details");
+        }
+
+        if (digest.Trend != null && digest.Trend.Direction == "Declining")
+        {
+            steps.Add($"Score has dropped {Math.Abs(digest.Trend.ScoreChange)} points — review recent changes with `winsentinel --history --diff`");
+        }
+
+        if (digest.Score >= 90 && digest.CriticalCount == 0)
+        {
+            steps.Add("Strong posture! Consider saving a baseline: `winsentinel --baseline save good-state`");
+        }
+
+        if (steps.Count == 0)
+        {
+            steps.Add("System is in good shape — no immediate action required");
+        }
+
+        return steps;
+    }
+
+    private string GenerateAssessment(SecurityDigest digest)
+    {
+        if (digest.CriticalCount > 0)
+        {
+            return $"ATTENTION REQUIRED: {digest.CriticalCount} critical security issue(s) detected. Immediate remediation recommended.";
+        }
+
+        if (digest.Score >= 90)
+        {
+            var trendNote = digest.Trend?.Direction == "Improving" ? " and improving" : "";
+            return $"Excellent security posture{trendNote}. {digest.WarningCount} minor warning(s) remain.";
+        }
+
+        if (digest.Score >= 70)
+        {
+            return $"Good security posture with room for improvement. {digest.WarningCount} warning(s) should be reviewed.";
+        }
+
+        if (digest.Score >= 50)
+        {
+            return $"Fair security posture — several issues need attention. Review the {digest.WarningCount} warning(s) and apply recommended fixes.";
+        }
+
+        return $"Poor security posture — significant remediation needed. {digest.CriticalCount} critical and {digest.WarningCount} warning findings require action.";
+    }
+}
+
+/// <summary>
+/// Executive security digest — a concise summary of system security state.
+/// </summary>
+public class SecurityDigest
+{
+    public DateTimeOffset GeneratedAt { get; set; }
+    public string MachineName { get; set; } = "";
+    public int Score { get; set; }
+    public string Grade { get; set; } = "";
+    public int TotalFindings { get; set; }
+    public int CriticalCount { get; set; }
+    public int WarningCount { get; set; }
+    public int InfoCount { get; set; }
+    public int PassCount { get; set; }
+    public string Assessment { get; set; } = "";
+    public List<DigestFinding> TopRisks { get; set; } = new();
+    public List<DigestModule> ModuleBreakdown { get; set; } = new();
+    public DigestTrend? Trend { get; set; }
+    public List<string> NextSteps { get; set; } = new();
+}
+
+public class DigestFinding
+{
+    public string Title { get; set; } = "";
+    public Severity Severity { get; set; }
+    public string Category { get; set; } = "";
+    public string? Remediation { get; set; }
+    public bool HasAutoFix { get; set; }
+}
+
+public class DigestModule
+{
+    public string Name { get; set; } = "";
+    public int Score { get; set; }
+    public int Critical { get; set; }
+    public int Warnings { get; set; }
+    public string Status { get; set; } = "";
+}
+
+public class DigestTrend
+{
+    public int PreviousScore { get; set; }
+    public int ScoreChange { get; set; }
+    public string Direction { get; set; } = "";
+    public int TotalScans { get; set; }
+    public int BestScore { get; set; }
+    public int WorstScore { get; set; }
+    public int AverageScore { get; set; }
+    public int Streak { get; set; }
+    public DateTimeOffset FirstScanDate { get; set; }
+    public DateTimeOffset LastScanDate { get; set; }
+}

--- a/tests/WinSentinel.Tests/SecurityDigestServiceTests.cs
+++ b/tests/WinSentinel.Tests/SecurityDigestServiceTests.cs
@@ -1,0 +1,197 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests;
+
+public class SecurityDigestServiceTests
+{
+    private SecurityReport CreateReport(int criticals = 0, int warnings = 2, int infos = 1, int passes = 5)
+    {
+        var findings = new List<Finding>();
+        for (int i = 0; i < criticals; i++)
+            findings.Add(Finding.Critical($"Critical Issue {i + 1}", "Desc", "Firewall", "Fix it"));
+        for (int i = 0; i < warnings; i++)
+            findings.Add(Finding.Warning($"Warning Issue {i + 1}", "Desc", "Network", "Review it", "Set-Something"));
+        for (int i = 0; i < infos; i++)
+            findings.Add(Finding.Info($"Info Issue {i + 1}", "Desc", "System"));
+        for (int i = 0; i < passes; i++)
+            findings.Add(Finding.Pass($"Pass {i + 1}", "OK", "System"));
+
+        var result = new AuditResult
+        {
+            ModuleName = "TestModule",
+            Category = "Test Category",
+            Findings = findings,
+            Success = true,
+            StartTime = DateTimeOffset.UtcNow.AddSeconds(-1),
+            EndTime = DateTimeOffset.UtcNow
+        };
+
+        var report = new SecurityReport { Results = new List<AuditResult> { result } };
+        report.SecurityScore = SecurityScorer.CalculateScore(report);
+        return report;
+    }
+
+    private List<AuditRunRecord> CreateHistory(params int[] scores)
+    {
+        var runs = new List<AuditRunRecord>();
+        var baseDate = DateTimeOffset.UtcNow.AddDays(-scores.Length);
+        for (int i = 0; i < scores.Length; i++)
+        {
+            runs.Add(new AuditRunRecord
+            {
+                Id = i + 1,
+                Timestamp = baseDate.AddDays(i),
+                OverallScore = scores[i],
+                Grade = SecurityScorer.GetGrade(scores[i]),
+                TotalFindings = 5,
+                CriticalCount = scores[i] < 50 ? 2 : 0,
+                WarningCount = scores[i] < 80 ? 3 : 1,
+                InfoCount = 1,
+                PassCount = 3,
+            });
+        }
+        return runs;
+    }
+
+    [Fact]
+    public void Generate_BasicReport_ReturnsDigest()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport();
+        var digest = service.Generate(report);
+
+        Assert.NotNull(digest);
+        Assert.Equal(Environment.MachineName, digest.MachineName);
+        Assert.True(digest.Score >= 0 && digest.Score <= 100);
+        Assert.NotEmpty(digest.Grade);
+        Assert.NotEmpty(digest.Assessment);
+        Assert.NotEmpty(digest.NextSteps);
+    }
+
+    [Fact]
+    public void Generate_WithCriticalFindings_HighlightsInTopRisks()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport(criticals: 3, warnings: 2);
+        var digest = service.Generate(report);
+
+        Assert.True(digest.CriticalCount == 3);
+        Assert.True(digest.TopRisks.Count > 0);
+        Assert.Equal(Severity.Critical, digest.TopRisks[0].Severity);
+        Assert.Contains("ATTENTION", digest.Assessment);
+    }
+
+    [Fact]
+    public void Generate_WithHistory_IncludesTrend()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport(warnings: 1);
+        var history = CreateHistory(70, 75, 80, 85);
+        var digest = service.Generate(report, history);
+
+        Assert.NotNull(digest.Trend);
+        Assert.Equal("Improving", digest.Trend!.Direction);
+        Assert.Equal(5, digest.Trend.ScoreChange);
+        Assert.Equal(4, digest.Trend.TotalScans);
+        Assert.Equal(85, digest.Trend.BestScore);
+        Assert.Equal(70, digest.Trend.WorstScore);
+    }
+
+    [Fact]
+    public void Generate_DecliningTrend_ShowsWarning()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport(criticals: 1, warnings: 3);
+        var history = CreateHistory(90, 85, 80, 70);
+        var digest = service.Generate(report, history);
+
+        Assert.NotNull(digest.Trend);
+        Assert.Equal("Declining", digest.Trend!.Direction);
+        Assert.True(digest.Trend.ScoreChange < 0);
+        Assert.Contains(digest.NextSteps, s => s.Contains("dropped"));
+    }
+
+    [Fact]
+    public void Generate_NoHistory_TrendIsNull()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport();
+        var digest = service.Generate(report, null);
+
+        Assert.Null(digest.Trend);
+    }
+
+    [Fact]
+    public void Generate_SingleHistoryEntry_TrendIsNull()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport();
+        var history = CreateHistory(80);
+        var digest = service.Generate(report, history);
+
+        Assert.Null(digest.Trend);
+    }
+
+    [Fact]
+    public void Generate_HighScore_SuggestsBaseline()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport(criticals: 0, warnings: 0, infos: 1, passes: 10);
+        var digest = service.Generate(report);
+
+        Assert.True(digest.Score >= 90);
+        Assert.Contains(digest.NextSteps, s => s.Contains("baseline"));
+    }
+
+    [Fact]
+    public void Generate_ModuleBreakdown_SortedByScore()
+    {
+        var findings1 = new List<Finding>
+        {
+            Finding.Critical("Bad thing", "Desc", "Firewall"),
+            Finding.Critical("Worse thing", "Desc", "Firewall"),
+        };
+        var findings2 = new List<Finding>
+        {
+            Finding.Pass("Good", "OK", "Network"),
+        };
+
+        var report = new SecurityReport
+        {
+            Results = new List<AuditResult>
+            {
+                new() { ModuleName = "FirewallAudit", Category = "Firewall", Findings = findings1, Success = true, StartTime = DateTimeOffset.UtcNow, EndTime = DateTimeOffset.UtcNow },
+                new() { ModuleName = "NetworkAudit", Category = "Network", Findings = findings2, Success = true, StartTime = DateTimeOffset.UtcNow, EndTime = DateTimeOffset.UtcNow },
+            }
+        };
+        report.SecurityScore = SecurityScorer.CalculateScore(report);
+
+        var service = new SecurityDigestService();
+        var digest = service.Generate(report);
+
+        Assert.Equal(2, digest.ModuleBreakdown.Count);
+        // Worst module first
+        Assert.True(digest.ModuleBreakdown[0].Score <= digest.ModuleBreakdown[1].Score);
+    }
+
+    [Fact]
+    public void Generate_TopRisks_MaxFive()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport(criticals: 4, warnings: 5);
+        var digest = service.Generate(report);
+
+        Assert.True(digest.TopRisks.Count <= 5);
+    }
+
+    [Fact]
+    public void Generate_AutoFixable_MentionedInNextSteps()
+    {
+        var service = new SecurityDigestService();
+        var report = CreateReport(warnings: 3); // warnings have FixCommand set
+        var digest = service.Generate(report);
+
+        Assert.Contains(digest.NextSteps, s => s.Contains("fix-all") || s.Contains("auto-fix"));
+    }
+}


### PR DESCRIPTION
## What

Adds a new \--digest\ (\-d\) command that generates a concise one-shot executive security digest — everything you need to know about your system's security posture in one screen.

## Why

Currently, getting a full picture requires running multiple commands (\--score\, \--trend\, \--audit\, \--checklist\). The digest combines the most important information from all of these into a single, scannable output.

## What's included in the digest

- **Score & grade** with inline trend indicator (↑/↓/→)
- **Assessment** — one-line human-readable summary of posture
- **Top 5 risks** — critical + warning findings with remediation hints and auto-fix tags
- **Module score heat map** — visual bars showing each module's score
- **Prioritized next steps** — actionable CLI commands to improve security

## New CLI options

| Flag | Description |
|------|-------------|
| \--digest\, \-d\ | Generate executive security digest |
| \--digest-days <n>\ | History window for trend data (default: 30) |
| \--no-trend\ | Skip trend analysis (faster, no DB read) |

Works with existing flags: \--json\, \-o <file>\, \--quiet\, \--modules\

## Files changed

- **New:** \SecurityDigestService.cs\ — digest generation with trend analysis, risk ranking, next-step generation
- **New:** \SecurityDigestServiceTests.cs\ — 10 unit tests (all passing)
- **Modified:** \CliParser.cs\ — new command enum + parser cases
- **Modified:** \Program.cs\ — \HandleDigest\ + \PrintDigestConsole\ (170 lines of formatted console output)
- **Modified:** \ConsoleFormatter.cs\ — help text entry

## Tests

10 new tests covering: basic generation, critical findings, trend directions, module sorting, top risks cap, auto-fix suggestions, baseline recommendations, edge cases (no history, single scan).