### PR TITLE
feat: Add --surface CLI command for attack surface analysis

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -64,6 +64,8 @@ public class CliOptions
     public ExemptionAction ExemptionAction { get; set; } = ExemptionAction.None;
     public int ExemptionWarningDays { get; set; } = 7;
     public int ExemptionStaleDays { get; set; } = 90;
+    public SurfaceAction SurfaceAction { get; set; } = SurfaceAction.None;
+    public int SurfaceTopActions { get; set; } = 10;
 }
 
 public enum CliCommand
@@ -85,6 +87,7 @@ public enum CliCommand
     Harden,
     Policy,
     Exemptions,
+    Surface,
     Help,
     Version
 }
@@ -145,6 +148,15 @@ public enum ExemptionAction
     Stale,
     Unused,
     Summary
+}
+
+public enum SurfaceAction
+{
+    None,
+    Full,
+    Vectors,
+    Actions,
+    Compare
 }
 
 /// <summary>
@@ -212,6 +224,51 @@ public static class CliParser
 
                 case "--status":
                     options.Command = CliCommand.Status;
+                    break;
+
+                case "--surface":
+                    options.Command = CliCommand.Surface;
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith("-"))
+                    {
+                        var surfaceAction = args[++i].ToLowerInvariant();
+                        options.SurfaceAction = surfaceAction switch
+                        {
+                            "full" => SurfaceAction.Full,
+                            "vectors" => SurfaceAction.Vectors,
+                            "actions" => SurfaceAction.Actions,
+                            "compare" => SurfaceAction.Compare,
+                            _ => SurfaceAction.None
+                        };
+                        if (options.SurfaceAction == SurfaceAction.None)
+                        {
+                            options.Error = $"Unknown surface action: {surfaceAction}. Use full, vectors, actions, or compare.";
+                            return options;
+                        }
+                    }
+                    else
+                    {
+                        options.SurfaceAction = SurfaceAction.Full;
+                    }
+                    break;
+
+                case "--top-actions":
+                    if (i + 1 < args.Length)
+                    {
+                        if (int.TryParse(args[++i], out int topActions) && topActions >= 1 && topActions <= 50)
+                        {
+                            options.SurfaceTopActions = topActions;
+                        }
+                        else
+                        {
+                            options.Error = "Invalid top-actions value. Must be 1-50.";
+                            return options;
+                        }
+                    }
+                    else
+                    {
+                        options.Error = "Missing value for --top-actions.";
+                        return options;
+                    }
                     break;
 
                 case "--harden":

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -312,6 +312,10 @@ public static partial class ConsoleFormatter
         Console.ForegroundColor = original;
         Console.WriteLine("Security Policy as Code (export/import/validate/diff)");
         Console.ForegroundColor = ConsoleColor.White;
+        Console.Write("    --surface [view]     ");
+        Console.ForegroundColor = original;
+        Console.WriteLine("Attack surface analysis (full/vectors/actions/compare)");
+        Console.ForegroundColor = ConsoleColor.White;
         Console.Write("    --help, -h           ");
         Console.ForegroundColor = original;
         Console.WriteLine("Show this help message");

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -36,6 +36,7 @@ return options.Command switch
     CliCommand.Harden => await HandleHarden(options),
     CliCommand.Policy => HandlePolicy(options),
     CliCommand.Exemptions => HandleExemptions(options),
+    CliCommand.Surface => await HandleSurface(options),
     _ => HandleHelp()
 };
 
@@ -412,6 +413,252 @@ static ConsoleColor GetScoreColor(int score)
         >= 60 => ConsoleColor.Yellow,
         _ => ConsoleColor.Red
     };
+}
+
+// ── Attack Surface Analysis ──────────────────────────────────────────
+
+static async Task<int> HandleSurface(CliOptions options)
+{
+    var engine = BuildEngine(options.ModulesFilter);
+    var sw = Stopwatch.StartNew();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintBanner();
+        Console.WriteLine("  Running audit for attack surface analysis...");
+        Console.WriteLine();
+    }
+
+    var progress = options.Quiet || options.Json
+        ? null
+        : new Progress<(string module, int current, int total)>(p =>
+            ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
+
+    var report = await engine.RunFullAuditAsync(progress);
+    sw.Stop();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintProgressDone(engine.Modules.Count, sw.Elapsed);
+    }
+
+    var analyzer = new AttackSurfaceAnalyzer();
+    var surfaceReport = analyzer.Analyze(report);
+
+    if (options.Json)
+    {
+        var jsonResult = new
+        {
+            overallScore = surfaceReport.OverallScore,
+            overallGrade = surfaceReport.OverallGrade,
+            totalFindings = surfaceReport.TotalFindings,
+            totalCritical = surfaceReport.TotalCritical,
+            totalWarnings = surfaceReport.TotalWarnings,
+            mostExposedVector = surfaceReport.MostExposedVector?.ToString(),
+            leastExposedVector = surfaceReport.LeastExposedVector?.ToString(),
+            vectors = surfaceReport.Vectors
+                .Where(v => v.TotalFindings > 0 || options.SurfaceAction == SurfaceAction.Full)
+                .OrderByDescending(v => v.ExposureScore)
+                .Select(v => new
+                {
+                    vector = v.DisplayName,
+                    exposureScore = v.ExposureScore,
+                    grade = v.Grade,
+                    totalFindings = v.TotalFindings,
+                    critical = v.CriticalCount,
+                    warnings = v.WarningCount,
+                    info = v.InfoCount,
+                    pass = v.PassCount,
+                    modules = v.ContributingModules,
+                    recommendations = v.Recommendations
+                }),
+            topActions = surfaceReport.TopActions.Take(options.SurfaceTopActions).Select(a => new
+            {
+                action = a.Action,
+                vector = a.Vector.ToString(),
+                priority = a.Priority.ToString(),
+                estimatedReduction = a.EstimatedReduction,
+                relatedFinding = a.RelatedFindingTitle
+            }),
+            timestamp = DateTimeOffset.Now
+        };
+        var jsonOptions = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+        var json = JsonSerializer.Serialize(jsonResult, jsonOptions);
+        WriteOutput(json, options.OutputFile);
+        return 0;
+    }
+
+    // Console output
+    var orig = Console.ForegroundColor;
+    Console.WriteLine();
+    Console.ForegroundColor = ConsoleColor.Cyan;
+    Console.WriteLine("  ╔══════════════════════════════════════════════╗");
+    Console.WriteLine("  ║       🎯 Attack Surface Analysis            ║");
+    Console.WriteLine("  ╚══════════════════════════════════════════════╝");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    // Overall score
+    var scoreColor = surfaceReport.OverallScore switch
+    {
+        <= 25 => ConsoleColor.Green,
+        <= 45 => ConsoleColor.Yellow,
+        _ => ConsoleColor.Red
+    };
+
+    Console.Write("  Exposure Score: ");
+    Console.ForegroundColor = scoreColor;
+    Console.Write($"{surfaceReport.OverallScore:F1}/100");
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.Write($" (Grade: {surfaceReport.OverallGrade})");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    Console.Write("  Findings:       ");
+    Console.ForegroundColor = ConsoleColor.White;
+    Console.Write($"{surfaceReport.TotalFindings} total");
+    if (surfaceReport.TotalCritical > 0)
+    {
+        Console.Write(" (");
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.Write($"{surfaceReport.TotalCritical} critical");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write($", {surfaceReport.TotalWarnings} warnings)");
+    }
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+    Console.WriteLine();
+
+    // Vector breakdown (show if not actions-only)
+    if (options.SurfaceAction != SurfaceAction.Actions)
+    {
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine("  ATTACK VECTORS");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  ──────────────────────────────────────────────────────────────");
+        Console.ForegroundColor = orig;
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine($"  {"Vector",-18} {"Score",7} {"Grade",6} {"Crit",5} {"Warn",5} {"Info",5} {"Pass",5}");
+        Console.WriteLine($"  {"──────────────────",-18} {"───────",7} {"──────",6} {"─────",5} {"─────",5} {"─────",5} {"─────",5}");
+        Console.ForegroundColor = orig;
+
+        foreach (var v in surfaceReport.Vectors.OrderByDescending(v => v.ExposureScore))
+        {
+            if (v.TotalFindings == 0 && options.SurfaceAction == SurfaceAction.Vectors)
+                continue;
+
+            var vColor = v.ExposureScore switch
+            {
+                <= 10 => ConsoleColor.Green,
+                <= 25 => ConsoleColor.DarkGreen,
+                <= 45 => ConsoleColor.Yellow,
+                <= 65 => ConsoleColor.DarkYellow,
+                _ => ConsoleColor.Red
+            };
+
+            Console.Write($"  {v.DisplayName,-18} ");
+            Console.ForegroundColor = vColor;
+            Console.Write($"{v.ExposureScore,6:F1}");
+            Console.ForegroundColor = orig;
+            Console.Write($"  {v.Grade,4}");
+
+            if (v.CriticalCount > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.Write($"  {v.CriticalCount,4}");
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write($"  {v.CriticalCount,4}");
+            }
+
+            if (v.WarningCount > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write($"  {v.WarningCount,4}");
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write($"  {v.WarningCount,4}");
+            }
+
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write($"  {v.InfoCount,4}  {v.PassCount,4}");
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+        }
+
+        Console.WriteLine();
+
+        if (surfaceReport.MostExposedVector.HasValue)
+        {
+            Console.Write("  Most Exposed:  ");
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine(surfaceReport.MostExposedVector.Value);
+            Console.ForegroundColor = orig;
+        }
+        if (surfaceReport.LeastExposedVector.HasValue && surfaceReport.LeastExposedVector != surfaceReport.MostExposedVector)
+        {
+            Console.Write("  Least Exposed: ");
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine(surfaceReport.LeastExposedVector.Value);
+            Console.ForegroundColor = orig;
+        }
+        Console.WriteLine();
+    }
+
+    // Top reduction actions (show if not vectors-only)
+    if (options.SurfaceAction != SurfaceAction.Vectors && surfaceReport.TopActions.Count > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine("  TOP REDUCTION ACTIONS");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  ──────────────────────────────────────────────────────────────");
+        Console.ForegroundColor = orig;
+
+        var displayActions = surfaceReport.TopActions.Take(options.SurfaceTopActions).ToList();
+        for (int i = 0; i < displayActions.Count; i++)
+        {
+            var a = displayActions[i];
+            var priorityColor = a.Priority switch
+            {
+                AttackSurfaceAnalyzer.ActionPriority.Critical => ConsoleColor.Red,
+                AttackSurfaceAnalyzer.ActionPriority.High => ConsoleColor.Yellow,
+                AttackSurfaceAnalyzer.ActionPriority.Medium => ConsoleColor.White,
+                _ => ConsoleColor.DarkGray
+            };
+
+            Console.Write($"  {i + 1,3}. ");
+            Console.ForegroundColor = priorityColor;
+            Console.Write($"[{a.Priority}]");
+            Console.ForegroundColor = ConsoleColor.White;
+
+            // Truncate long action text
+            var actionText = a.Action.Length > 60 ? a.Action[..57] + "..." : a.Action;
+            Console.Write($" {actionText}");
+
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write($" ({a.Vector}, ~{a.EstimatedReduction:F0}pt)");
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+        }
+
+        Console.WriteLine();
+    }
+
+    if (!options.Quiet)
+    {
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  Lower exposure score = smaller attack surface = more secure");
+        Console.WriteLine("  Options: --surface vectors | --surface actions | --top-actions N | --json");
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+    }
+
+    return 0;
 }
 
 // ── Command Handlers ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Exposes the existing \AttackSurfaceAnalyzer\ service through the CLI, giving users visibility into their system's attack surface broken down by vector.

## New Command

\\\
winsentinel --surface              # Full analysis (vectors + actions)
winsentinel --surface vectors      # Vector breakdown table only
winsentinel --surface actions      # Prioritized reduction actions only
winsentinel --surface --json       # JSON output
winsentinel --surface --top-actions 5  # Limit action count
\\\

## What it shows

- **Overall exposure score** (0-100, lower is better) with grade
- **Per-vector breakdown**: Network, Authentication, RemoteAccess, Software, DataExposure, PhysicalAccess, Configuration, Privilege
- **Prioritized reduction actions** with estimated impact points
- Full JSON output support for CI/automation

## Changes

- \CliParser.cs\: Added \--surface\ command parsing, \SurfaceAction\ enum, \--top-actions\ option
- \Program.cs\: Added \HandleSurface()\ with rich console output and JSON serialization
- \ConsoleFormatter.cs\: Added help text entry for the new command

## Testing

- Build succeeds with 0 errors
- Existing commands unaffected (no breaking changes)