### PR TITLE
feat: Security Changelog - narrative history of security posture changes

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -64,6 +64,8 @@ public class CliOptions
     public ExemptionAction ExemptionAction { get; set; } = ExemptionAction.None;
     public int ExemptionWarningDays { get; set; } = 7;
     public int ExemptionStaleDays { get; set; } = 90;
+    public int ChangelogDays { get; set; } = 30;
+    public string? ChangelogModuleFilter { get; set; }
 }
 
 public enum CliCommand
@@ -85,6 +87,7 @@ public enum CliCommand
     Harden,
     Policy,
     Exemptions,
+    Changelog,
     Help,
     Version
 }
@@ -247,6 +250,42 @@ public static class CliParser
                     {
                         // Default to full review
                         options.ExemptionAction = ExemptionAction.Review;
+                    }
+                    break;
+
+                case "--changelog":
+                    options.Command = CliCommand.Changelog;
+                    break;
+
+                case "--changelog-days":
+                    if (i + 1 < args.Length)
+                    {
+                        if (int.TryParse(args[++i], out int clDays) && clDays >= 1 && clDays <= 365)
+                        {
+                            options.ChangelogDays = clDays;
+                        }
+                        else
+                        {
+                            options.Error = "Invalid changelog-days value. Must be 1-365.";
+                            return options;
+                        }
+                    }
+                    else
+                    {
+                        options.Error = "Missing value for --changelog-days.";
+                        return options;
+                    }
+                    break;
+
+                case "--changelog-module":
+                    if (i + 1 < args.Length)
+                    {
+                        options.ChangelogModuleFilter = args[++i];
+                    }
+                    else
+                    {
+                        options.Error = "Missing value for --changelog-module.";
+                        return options;
                     }
                     break;
 

--- a/src/WinSentinel.Cli/ConsoleFormatter.Changelog.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Changelog.cs
@@ -1,0 +1,119 @@
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Cli;
+
+public static partial class ConsoleFormatter
+{
+    /// <summary>
+    /// Print a formatted security changelog to the console.
+    /// </summary>
+    public static void PrintChangelog(ChangelogReport report, bool quiet = false)
+    {
+        if (report.TotalScans == 0)
+        {
+            WriteLineColored("  No audit history found. Run some audits first!", ConsoleColor.Yellow);
+            return;
+        }
+
+        if (!quiet)
+        {
+            Console.WriteLine();
+            WriteLineColored("  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+            WriteLineColored("  ║       📋  Security Changelog                ║", ConsoleColor.Cyan);
+            WriteLineColored("  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+            Console.WriteLine();
+        }
+
+        // Summary header
+        WriteLineColored($"  Period: last {report.Period} days ({report.TotalScans} scans)", ConsoleColor.White);
+        if (report.FirstScan.HasValue && report.LastScan.HasValue)
+        {
+            WriteColored("  Range:  ", ConsoleColor.DarkGray);
+            Console.WriteLine($"{report.FirstScan.Value:yyyy-MM-dd} → {report.LastScan.Value:yyyy-MM-dd}");
+        }
+
+        // Score summary
+        Console.WriteLine();
+        WriteColored("  Score:  ", ConsoleColor.DarkGray);
+        var scoreColor = report.NetScoreChange > 0 ? ConsoleColor.Green
+            : report.NetScoreChange < 0 ? ConsoleColor.Red : ConsoleColor.Yellow;
+        var arrow = report.NetScoreChange > 0 ? "↑" : report.NetScoreChange < 0 ? "↓" : "→";
+        WriteLineColored(
+            $"{report.StartScore} → {report.EndScore} ({report.StartGrade} → {report.EndGrade}) " +
+            $"{arrow} {(report.NetScoreChange >= 0 ? "+" : "")}{report.NetScoreChange}",
+            scoreColor);
+
+        WriteColored("  Best:   ", ConsoleColor.DarkGray);
+        WriteLineColored($"{report.BestScore}", ConsoleColor.Green);
+        WriteColored("  Worst:  ", ConsoleColor.DarkGray);
+        WriteLineColored($"{report.WorstScore}", ConsoleColor.Red);
+        WriteColored("  Stats:  ", ConsoleColor.DarkGray);
+        Console.WriteLine($"{report.ImprovementCount} improvements, {report.RegressionCount} regressions");
+
+        // Milestones
+        if (report.Milestones.Count > 0)
+        {
+            Console.WriteLine();
+            WriteLineColored("  🏆 Milestones", ConsoleColor.Yellow);
+            WriteLineColored("  " + new string('─', 50), ConsoleColor.DarkGray);
+            foreach (var m in report.Milestones)
+            {
+                WriteColored($"  {m.Timestamp:MM-dd HH:mm}  ", ConsoleColor.DarkGray);
+                WriteLineColored(m.Description, ConsoleColor.Yellow);
+            }
+        }
+
+        // Changelog entries (newest first)
+        if (report.Entries.Count > 0)
+        {
+            Console.WriteLine();
+            WriteLineColored("  📜 Changes", ConsoleColor.White);
+            WriteLineColored("  " + new string('─', 50), ConsoleColor.DarkGray);
+
+            foreach (var entry in report.Entries.AsEnumerable().Reverse().Take(quiet ? 5 : 20))
+            {
+                Console.WriteLine();
+                WriteColored($"  {entry.Timestamp:yyyy-MM-dd HH:mm}  ", ConsoleColor.DarkGray);
+                var entryColor = entry.ScoreChange > 0 ? ConsoleColor.Green
+                    : entry.ScoreChange < 0 ? ConsoleColor.Red : ConsoleColor.White;
+                WriteLineColored(
+                    $"Score: {entry.PreviousScore} → {entry.CurrentScore}",
+                    entryColor);
+
+                foreach (var evt in entry.Events)
+                {
+                    WriteLineColored($"    {evt.Icon} {evt.Summary}", entryColor);
+                }
+
+                // Module changes
+                foreach (var mod in entry.ModuleChanges.OrderByDescending(m => Math.Abs(m.Delta)).Take(3))
+                {
+                    var modColor = mod.Delta > 0 ? ConsoleColor.Green : ConsoleColor.Red;
+                    WriteColored($"    │ ", ConsoleColor.DarkGray);
+                    WriteLineColored(
+                        $"{mod.ModuleName}: {mod.PreviousScore} → {mod.CurrentScore} ({(mod.Delta > 0 ? "+" : "")}{mod.Delta})",
+                        modColor);
+                }
+
+                // Finding changes
+                foreach (var fc in entry.FindingChanges)
+                {
+                    var fcIcon = fc.Type == FindingChangeType.Resolved ? "  ✓" : "  ✗";
+                    var fcColor = fc.Type == FindingChangeType.Resolved ? ConsoleColor.Green : ConsoleColor.Red;
+                    WriteColored($"    │ ", ConsoleColor.DarkGray);
+                    WriteColored(fcIcon, fcColor);
+                    WriteColored($" [{fc.Severity}] ", ConsoleColor.DarkGray);
+                    WriteLineColored(fc.Title, fcColor);
+                }
+
+                if (entry.FindingChangesOmitted > 0)
+                {
+                    WriteColored($"    │ ", ConsoleColor.DarkGray);
+                    WriteLineColored($"  ... and {entry.FindingChangesOmitted} more", ConsoleColor.DarkGray);
+                }
+            }
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -36,6 +36,7 @@ return options.Command switch
     CliCommand.Harden => await HandleHarden(options),
     CliCommand.Policy => HandlePolicy(options),
     CliCommand.Exemptions => HandleExemptions(options),
+    CliCommand.Changelog => HandleChangelog(options),
     _ => HandleHelp()
 };
 
@@ -2490,4 +2491,38 @@ static object FormatReviewedRuleJson(ExemptionReviewService.ReviewedRule r)
         matchCount = r.MatchCount,
         recommendation = r.Recommendation
     };
+}
+
+// ── Security Changelog ───────────────────────────────────────────────
+
+static int HandleChangelog(CliOptions options)
+{
+    using var history = new AuditHistoryService();
+    var service = new SecurityChangelogService(history);
+    var report = service.Generate(options.ChangelogDays, options.ChangelogModuleFilter);
+
+    if (options.Json)
+    {
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var json = JsonSerializer.Serialize(report, jsonOptions);
+
+        if (options.OutputFile != null)
+        {
+            File.WriteAllText(options.OutputFile, json);
+            Console.WriteLine($"  Changelog written to {options.OutputFile}");
+        }
+        else
+        {
+            Console.WriteLine(json);
+        }
+        return 0;
+    }
+
+    ConsoleFormatter.PrintChangelog(report, options.Quiet);
+    return 0;
 }

--- a/src/WinSentinel.Core/Services/SecurityChangelogService.cs
+++ b/src/WinSentinel.Core/Services/SecurityChangelogService.cs
@@ -1,0 +1,469 @@
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+/// <summary>
+/// Generates a human-readable security changelog from audit history.
+/// Each entry describes what changed between consecutive audit runs:
+/// score movements, findings resolved/introduced, grade transitions,
+/// and notable milestones (streaks, all-clear, regressions).
+/// </summary>
+public class SecurityChangelogService
+{
+    private readonly AuditHistoryService _history;
+
+    public SecurityChangelogService(AuditHistoryService history)
+    {
+        _history = history;
+    }
+
+    /// <summary>
+    /// Generate a changelog covering the specified number of days.
+    /// </summary>
+    public ChangelogReport Generate(int days = 30, string? moduleFilter = null)
+    {
+        var runs = _history.GetHistory(days);
+        if (runs.Count == 0)
+            return new ChangelogReport { Period = days };
+
+        // Runs come newest-first; we need oldest-first for chronological processing
+        var chronological = runs.OrderBy(r => r.Timestamp).ToList();
+
+        var report = new ChangelogReport
+        {
+            Period = days,
+            TotalScans = chronological.Count,
+            FirstScan = chronological[0].Timestamp,
+            LastScan = chronological[^1].Timestamp,
+            StartScore = chronological[0].OverallScore,
+            EndScore = chronological[^1].OverallScore,
+            StartGrade = chronological[0].Grade,
+            EndGrade = chronological[^1].Grade
+        };
+
+        // Load detailed findings for each run to detect new/resolved findings
+        var runDetails = new Dictionary<long, AuditRunRecord>();
+        foreach (var run in chronological)
+        {
+            var detail = _history.GetRunDetails(run.Id);
+            if (detail != null)
+                runDetails[run.Id] = detail;
+        }
+
+        // Generate entries by comparing consecutive runs
+        for (int i = 1; i < chronological.Count; i++)
+        {
+            var prev = chronological[i - 1];
+            var curr = chronological[i];
+
+            var entry = BuildEntry(prev, curr, runDetails, moduleFilter);
+            if (entry.Events.Count > 0)
+                report.Entries.Add(entry);
+        }
+
+        // Detect milestones
+        report.Milestones = DetectMilestones(chronological);
+
+        // Summary stats
+        report.NetScoreChange = report.EndScore - report.StartScore;
+        report.BestScore = chronological.Max(r => r.OverallScore);
+        report.WorstScore = chronological.Min(r => r.OverallScore);
+
+        var improvements = 0;
+        var regressions = 0;
+        for (int i = 1; i < chronological.Count; i++)
+        {
+            if (chronological[i].OverallScore > chronological[i - 1].OverallScore)
+                improvements++;
+            else if (chronological[i].OverallScore < chronological[i - 1].OverallScore)
+                regressions++;
+        }
+        report.ImprovementCount = improvements;
+        report.RegressionCount = regressions;
+
+        return report;
+    }
+
+    private ChangelogEntry BuildEntry(
+        AuditRunRecord prev, AuditRunRecord curr,
+        Dictionary<long, AuditRunRecord> details,
+        string? moduleFilter)
+    {
+        var entry = new ChangelogEntry
+        {
+            Timestamp = curr.Timestamp,
+            PreviousScore = prev.OverallScore,
+            CurrentScore = curr.OverallScore,
+            PreviousGrade = prev.Grade,
+            CurrentGrade = curr.Grade,
+            ScoreChange = curr.OverallScore - prev.OverallScore
+        };
+
+        // Score change event
+        if (entry.ScoreChange != 0)
+        {
+            var direction = entry.ScoreChange > 0 ? "improved" : "regressed";
+            var icon = entry.ScoreChange > 0 ? "📈" : "📉";
+            entry.Events.Add(new ChangelogEvent
+            {
+                Type = entry.ScoreChange > 0 ? ChangelogEventType.Improvement : ChangelogEventType.Regression,
+                Icon = icon,
+                Summary = $"Score {direction} {prev.OverallScore} → {curr.OverallScore} ({(entry.ScoreChange > 0 ? "+" : "")}{entry.ScoreChange})"
+            });
+        }
+
+        // Grade change
+        if (prev.Grade != curr.Grade)
+        {
+            var better = IsGradeBetter(curr.Grade, prev.Grade);
+            entry.Events.Add(new ChangelogEvent
+            {
+                Type = better ? ChangelogEventType.GradeUp : ChangelogEventType.GradeDown,
+                Icon = better ? "⭐" : "⚠️",
+                Summary = $"Grade changed {prev.Grade} → {curr.Grade}"
+            });
+        }
+
+        // Critical findings change
+        var critDelta = curr.CriticalCount - prev.CriticalCount;
+        if (critDelta < 0)
+        {
+            entry.Events.Add(new ChangelogEvent
+            {
+                Type = ChangelogEventType.FindingsResolved,
+                Icon = "✅",
+                Summary = $"{Math.Abs(critDelta)} critical finding{(Math.Abs(critDelta) != 1 ? "s" : "")} resolved"
+            });
+        }
+        else if (critDelta > 0)
+        {
+            entry.Events.Add(new ChangelogEvent
+            {
+                Type = ChangelogEventType.FindingsIntroduced,
+                Icon = "🚨",
+                Summary = $"{critDelta} new critical finding{(critDelta != 1 ? "s" : "")} detected"
+            });
+        }
+
+        // Warning findings change
+        var warnDelta = curr.WarningCount - prev.WarningCount;
+        if (warnDelta < 0)
+        {
+            entry.Events.Add(new ChangelogEvent
+            {
+                Type = ChangelogEventType.FindingsResolved,
+                Icon = "✅",
+                Summary = $"{Math.Abs(warnDelta)} warning{(Math.Abs(warnDelta) != 1 ? "s" : "")} resolved"
+            });
+        }
+        else if (warnDelta > 0)
+        {
+            entry.Events.Add(new ChangelogEvent
+            {
+                Type = ChangelogEventType.FindingsIntroduced,
+                Icon = "⚠️",
+                Summary = $"{warnDelta} new warning{(warnDelta != 1 ? "s" : "")} detected"
+            });
+        }
+
+        // Per-finding diff if details available
+        if (details.TryGetValue(prev.Id, out var prevDetail) &&
+            details.TryGetValue(curr.Id, out var currDetail))
+        {
+            var prevFindings = GetFindingKeys(prevDetail, moduleFilter);
+            var currFindings = GetFindingKeys(currDetail, moduleFilter);
+
+            var resolved = prevFindings.Except(currFindings).ToList();
+            var introduced = currFindings.Except(prevFindings).ToList();
+
+            foreach (var f in resolved.Take(5))
+            {
+                entry.FindingChanges.Add(new FindingChange
+                {
+                    Type = FindingChangeType.Resolved,
+                    Title = f.Title,
+                    Module = f.Module,
+                    Severity = f.Severity
+                });
+            }
+            if (resolved.Count > 5)
+                entry.FindingChangesOmitted = resolved.Count - 5;
+
+            foreach (var f in introduced.Take(5))
+            {
+                entry.FindingChanges.Add(new FindingChange
+                {
+                    Type = FindingChangeType.Introduced,
+                    Title = f.Title,
+                    Module = f.Module,
+                    Severity = f.Severity
+                });
+            }
+            if (introduced.Count > 5)
+                entry.FindingChangesOmitted += introduced.Count - 5;
+
+            // Per-module score changes
+            var prevModules = prevDetail.ModuleScores.ToDictionary(m => m.ModuleName, m => m.Score);
+            var currModules = currDetail.ModuleScores.ToDictionary(m => m.ModuleName, m => m.Score);
+
+            foreach (var mod in currModules)
+            {
+                if (moduleFilter != null && !mod.Key.Contains(moduleFilter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (prevModules.TryGetValue(mod.Key, out var prevScore) && prevScore != mod.Value)
+                {
+                    entry.ModuleChanges.Add(new ModuleScoreChange
+                    {
+                        ModuleName = mod.Key,
+                        PreviousScore = prevScore,
+                        CurrentScore = mod.Value,
+                        Delta = mod.Value - prevScore
+                    });
+                }
+            }
+        }
+
+        // Zero-critical milestone
+        if (prev.CriticalCount > 0 && curr.CriticalCount == 0)
+        {
+            entry.Events.Add(new ChangelogEvent
+            {
+                Type = ChangelogEventType.Milestone,
+                Icon = "🎉",
+                Summary = "All critical findings cleared!"
+            });
+        }
+
+        return entry;
+    }
+
+    private static HashSet<FindingKey> GetFindingKeys(AuditRunRecord run, string? moduleFilter)
+    {
+        var findings = run.Findings.AsEnumerable();
+        if (moduleFilter != null)
+            findings = findings.Where(f => f.ModuleName.Contains(moduleFilter, StringComparison.OrdinalIgnoreCase));
+
+        return findings.Select(f => new FindingKey(f.ModuleName, f.Title, f.Severity)).ToHashSet();
+    }
+
+    private static List<ChangelogMilestone> DetectMilestones(List<AuditRunRecord> runs)
+    {
+        var milestones = new List<ChangelogMilestone>();
+
+        // Detect improvement streaks (3+ consecutive improvements)
+        int streakStart = -1;
+        int streakLen = 0;
+        for (int i = 1; i < runs.Count; i++)
+        {
+            if (runs[i].OverallScore > runs[i - 1].OverallScore)
+            {
+                if (streakLen == 0) streakStart = i - 1;
+                streakLen++;
+            }
+            else
+            {
+                if (streakLen >= 3)
+                {
+                    milestones.Add(new ChangelogMilestone
+                    {
+                        Type = MilestoneType.ImprovementStreak,
+                        Timestamp = runs[streakStart].Timestamp,
+                        Description = $"{streakLen}-scan improvement streak ({runs[streakStart].OverallScore} → {runs[streakStart + streakLen].OverallScore})"
+                    });
+                }
+                streakLen = 0;
+            }
+        }
+        if (streakLen >= 3)
+        {
+            milestones.Add(new ChangelogMilestone
+            {
+                Type = MilestoneType.ImprovementStreak,
+                Timestamp = runs[streakStart].Timestamp,
+                Description = $"{streakLen}-scan improvement streak ({runs[streakStart].OverallScore} → {runs[streakStart + streakLen].OverallScore})"
+            });
+        }
+
+        // Perfect score
+        foreach (var run in runs)
+        {
+            if (run.OverallScore == 100)
+            {
+                milestones.Add(new ChangelogMilestone
+                {
+                    Type = MilestoneType.PerfectScore,
+                    Timestamp = run.Timestamp,
+                    Description = "Achieved perfect security score (100/100)!"
+                });
+                break; // Only first occurrence
+            }
+        }
+
+        // Grade transitions (first time reaching A+, A, etc.)
+        var seenGrades = new HashSet<string>();
+        foreach (var run in runs)
+        {
+            if (seenGrades.Add(run.Grade) && run.Grade is "A+" or "A")
+            {
+                milestones.Add(new ChangelogMilestone
+                {
+                    Type = MilestoneType.GradeAchievement,
+                    Timestamp = run.Timestamp,
+                    Description = $"First time achieving grade {run.Grade}"
+                });
+            }
+        }
+
+        // Biggest single-scan improvement
+        int biggestJump = 0;
+        int biggestIdx = -1;
+        for (int i = 1; i < runs.Count; i++)
+        {
+            var delta = runs[i].OverallScore - runs[i - 1].OverallScore;
+            if (delta > biggestJump)
+            {
+                biggestJump = delta;
+                biggestIdx = i;
+            }
+        }
+        if (biggestJump >= 5 && biggestIdx >= 0)
+        {
+            milestones.Add(new ChangelogMilestone
+            {
+                Type = MilestoneType.BiggestImprovement,
+                Timestamp = runs[biggestIdx].Timestamp,
+                Description = $"Biggest single-scan improvement: +{biggestJump} points ({runs[biggestIdx - 1].OverallScore} → {runs[biggestIdx].OverallScore})"
+            });
+        }
+
+        // Zero-critical achievement
+        for (int i = 1; i < runs.Count; i++)
+        {
+            if (runs[i - 1].CriticalCount > 0 && runs[i].CriticalCount == 0)
+            {
+                milestones.Add(new ChangelogMilestone
+                {
+                    Type = MilestoneType.ZeroCritical,
+                    Timestamp = runs[i].Timestamp,
+                    Description = "Reached zero critical findings"
+                });
+                break;
+            }
+        }
+
+        return milestones.OrderBy(m => m.Timestamp).ToList();
+    }
+
+    public static bool IsGradeBetter(string current, string previous)
+    {
+        var order = new Dictionary<string, int>
+        {
+            ["A+"] = 7, ["A"] = 6, ["B"] = 5, ["C"] = 4,
+            ["D"] = 3, ["E"] = 2, ["F"] = 1
+        };
+        var currVal = order.GetValueOrDefault(current, 0);
+        var prevVal = order.GetValueOrDefault(previous, 0);
+        return currVal > prevVal;
+    }
+}
+
+// ── Models ──────────────────────────────────────────────────────────
+
+/// <summary>Key for deduplicating findings across runs.</summary>
+public record FindingKey(string Module, string Title, string Severity);
+
+/// <summary>Full changelog report.</summary>
+public class ChangelogReport
+{
+    public int Period { get; set; }
+    public int TotalScans { get; set; }
+    public DateTimeOffset? FirstScan { get; set; }
+    public DateTimeOffset? LastScan { get; set; }
+    public int StartScore { get; set; }
+    public int EndScore { get; set; }
+    public string StartGrade { get; set; } = "";
+    public string EndGrade { get; set; } = "";
+    public int NetScoreChange { get; set; }
+    public int BestScore { get; set; }
+    public int WorstScore { get; set; }
+    public int ImprovementCount { get; set; }
+    public int RegressionCount { get; set; }
+    public List<ChangelogEntry> Entries { get; set; } = [];
+    public List<ChangelogMilestone> Milestones { get; set; } = [];
+}
+
+/// <summary>One changelog entry (diff between two consecutive scans).</summary>
+public class ChangelogEntry
+{
+    public DateTimeOffset Timestamp { get; set; }
+    public int PreviousScore { get; set; }
+    public int CurrentScore { get; set; }
+    public string PreviousGrade { get; set; } = "";
+    public string CurrentGrade { get; set; } = "";
+    public int ScoreChange { get; set; }
+    public List<ChangelogEvent> Events { get; set; } = [];
+    public List<FindingChange> FindingChanges { get; set; } = [];
+    public List<ModuleScoreChange> ModuleChanges { get; set; } = [];
+    public int FindingChangesOmitted { get; set; }
+}
+
+/// <summary>A single event within a changelog entry.</summary>
+public class ChangelogEvent
+{
+    public ChangelogEventType Type { get; set; }
+    public string Icon { get; set; } = "";
+    public string Summary { get; set; } = "";
+}
+
+public enum ChangelogEventType
+{
+    Improvement,
+    Regression,
+    GradeUp,
+    GradeDown,
+    FindingsResolved,
+    FindingsIntroduced,
+    Milestone
+}
+
+/// <summary>A specific finding that was resolved or introduced.</summary>
+public class FindingChange
+{
+    public FindingChangeType Type { get; set; }
+    public string Title { get; set; } = "";
+    public string Module { get; set; } = "";
+    public string Severity { get; set; } = "";
+}
+
+public enum FindingChangeType
+{
+    Resolved,
+    Introduced
+}
+
+/// <summary>Module score change between consecutive scans.</summary>
+public class ModuleScoreChange
+{
+    public string ModuleName { get; set; } = "";
+    public int PreviousScore { get; set; }
+    public int CurrentScore { get; set; }
+    public int Delta { get; set; }
+}
+
+/// <summary>A notable milestone detected in the history.</summary>
+public class ChangelogMilestone
+{
+    public MilestoneType Type { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public string Description { get; set; } = "";
+}
+
+public enum MilestoneType
+{
+    ImprovementStreak,
+    PerfectScore,
+    GradeAchievement,
+    BiggestImprovement,
+    ZeroCritical
+}

--- a/tests/WinSentinel.Tests/InputSanitizerTests.cs
+++ b/tests/WinSentinel.Tests/InputSanitizerTests.cs
@@ -451,7 +451,7 @@ public class InputSanitizerTests
     [InlineData("Set-MpPreference -DisableRealtimeMonitoring $false")]
     [InlineData("Get-Service WinDefend")]
     [InlineData("netsh advfirewall firewall add rule name=\"Block\" dir=in action=block remoteip=1.2.3.4")]
-    public void CheckDangerousCommand_SafeCommands_ReturnsNull(string input)
+    public void CheckDangerousCommand_SafeRemediationCommands_ReturnsNull(string input)
     {
         // These legitimate remediation commands should NOT be blocked
         Assert.Null(InputSanitizer.CheckDangerousCommand(input));

--- a/tests/WinSentinel.Tests/Services/SecurityChangelogServiceTests.cs
+++ b/tests/WinSentinel.Tests/Services/SecurityChangelogServiceTests.cs
@@ -1,0 +1,457 @@
+using WinSentinel.Cli;
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests.Services;
+
+public class SecurityChangelogServiceTests : IDisposable
+{
+    private readonly string _dbPath;
+    private readonly AuditHistoryService _history;
+    private readonly SecurityChangelogService _service;
+
+    public SecurityChangelogServiceTests()
+    {
+        _dbPath = Path.Combine(Path.GetTempPath(), $"changelog-test-{Guid.NewGuid()}.db");
+        _history = new AuditHistoryService(_dbPath);
+        _service = new SecurityChangelogService(_history);
+    }
+
+    public void Dispose()
+    {
+        _history.Dispose();
+        // SQLite connection pooling on Windows may hold the file open briefly
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch (IOException) { /* best effort */ }
+    }
+
+    private SecurityReport MakeReport(int score, int criticals = 0, int warnings = 0, DateTimeOffset? timestamp = null,
+        List<(string module, string title, Severity severity)>? findings = null)
+    {
+        var report = new SecurityReport
+        {
+            SecurityScore = score,
+            GeneratedAt = timestamp ?? DateTimeOffset.UtcNow
+        };
+
+        var result = new AuditResult { ModuleName = "TestModule", Category = "Test" };
+        if (findings != null)
+        {
+            foreach (var (mod, title, sev) in findings)
+            {
+                result.Findings.Add(new Finding
+                {
+                    Title = title,
+                    Description = $"Description for {title}",
+                    Severity = sev,
+                    Category = "Test"
+                });
+            }
+        }
+        else
+        {
+            for (int i = 0; i < criticals; i++)
+                result.Findings.Add(Finding.Critical($"Critical-{i}", $"Critical finding {i}", "Test"));
+            for (int i = 0; i < warnings; i++)
+                result.Findings.Add(Finding.Warning($"Warning-{i}", $"Warning finding {i}", "Test"));
+        }
+
+        report.Results.Add(result);
+        return report;
+    }
+
+    [Fact]
+    public void EmptyHistory_ReturnsEmptyReport()
+    {
+        var report = _service.Generate();
+        Assert.Equal(0, report.TotalScans);
+        Assert.Empty(report.Entries);
+        Assert.Empty(report.Milestones);
+    }
+
+    [Fact]
+    public void SingleScan_NoEntries()
+    {
+        _history.SaveAuditResult(MakeReport(75, timestamp: DateTimeOffset.UtcNow));
+        var report = _service.Generate();
+        Assert.Equal(1, report.TotalScans);
+        Assert.Empty(report.Entries); // need 2 scans for a diff
+    }
+
+    [Fact]
+    public void TwoScans_ScoreImprovement_GeneratesEntry()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(60, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(80, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Equal(2, report.TotalScans);
+        Assert.Equal(60, report.StartScore);
+        Assert.Equal(80, report.EndScore);
+        Assert.Equal(20, report.NetScoreChange);
+        Assert.Single(report.Entries);
+        Assert.Contains(report.Entries[0].Events, e => e.Type == ChangelogEventType.Improvement);
+    }
+
+    [Fact]
+    public void TwoScans_ScoreRegression_DetectedAsRegression()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(90, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(70, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Equal(-20, report.NetScoreChange);
+        Assert.Contains(report.Entries[0].Events, e => e.Type == ChangelogEventType.Regression);
+    }
+
+    [Fact]
+    public void GradeChange_Detected()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(65, timestamp: t1)); // C
+        _history.SaveAuditResult(MakeReport(85, timestamp: t2)); // B
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].Events,
+            e => e.Type == ChangelogEventType.GradeUp || e.Type == ChangelogEventType.GradeDown);
+    }
+
+    [Fact]
+    public void CriticalFindings_ResolutionDetected()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(50, criticals: 3, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(80, criticals: 0, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].Events,
+            e => e.Type == ChangelogEventType.FindingsResolved && e.Summary.Contains("critical"));
+    }
+
+    [Fact]
+    public void NewCriticalFindings_Detected()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(80, criticals: 0, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(50, criticals: 2, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].Events,
+            e => e.Type == ChangelogEventType.FindingsIntroduced && e.Summary.Contains("critical"));
+    }
+
+    [Fact]
+    public void WarningChanges_Detected()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(70, warnings: 5, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(80, warnings: 2, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].Events,
+            e => e.Type == ChangelogEventType.FindingsResolved && e.Summary.Contains("warning"));
+    }
+
+    [Fact]
+    public void ZeroCritical_MilestoneEvent()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(50, criticals: 3, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(80, criticals: 0, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].Events,
+            e => e.Type == ChangelogEventType.Milestone && e.Summary.Contains("critical"));
+    }
+
+    [Fact]
+    public void ImprovementStreak_Milestone()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            _history.SaveAuditResult(MakeReport(50 + i * 10, timestamp: DateTimeOffset.UtcNow.AddHours(-10 + i)));
+        }
+
+        var report = _service.Generate();
+        Assert.Contains(report.Milestones, m => m.Type == MilestoneType.ImprovementStreak);
+    }
+
+    [Fact]
+    public void PerfectScore_Milestone()
+    {
+        _history.SaveAuditResult(MakeReport(90, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(100, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Milestones, m => m.Type == MilestoneType.PerfectScore);
+    }
+
+    [Fact]
+    public void BiggestImprovement_Milestone()
+    {
+        _history.SaveAuditResult(MakeReport(40, timestamp: DateTimeOffset.UtcNow.AddHours(-3)));
+        _history.SaveAuditResult(MakeReport(70, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(72, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Milestones, m => m.Type == MilestoneType.BiggestImprovement);
+    }
+
+    [Fact]
+    public void NoScoreChange_NoEntries()
+    {
+        _history.SaveAuditResult(MakeReport(75, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(75, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.Empty(report.Entries);
+    }
+
+    [Fact]
+    public void DayFilter_RespectsRange()
+    {
+        _history.SaveAuditResult(MakeReport(50, timestamp: DateTimeOffset.UtcNow.AddDays(-60)));
+        _history.SaveAuditResult(MakeReport(70, timestamp: DateTimeOffset.UtcNow.AddDays(-5)));
+        _history.SaveAuditResult(MakeReport(80, timestamp: DateTimeOffset.UtcNow.AddDays(-1)));
+
+        var report = _service.Generate(days: 10);
+        Assert.Equal(2, report.TotalScans);
+    }
+
+    [Fact]
+    public void FindingDiff_Resolved()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(60, findings: new()
+        {
+            ("Firewall", "Firewall disabled", Severity.Critical),
+            ("Updates", "Updates pending", Severity.Warning)
+        }, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(80, findings: new()
+        {
+            ("Updates", "Updates pending", Severity.Warning)
+        }, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Single(report.Entries);
+        Assert.Contains(report.Entries[0].FindingChanges,
+            fc => fc.Type == FindingChangeType.Resolved && fc.Title == "Firewall disabled");
+    }
+
+    [Fact]
+    public void FindingDiff_Introduced()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(80, findings: new()
+        {
+            ("Updates", "Updates pending", Severity.Warning)
+        }, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(60, findings: new()
+        {
+            ("Updates", "Updates pending", Severity.Warning),
+            ("Firewall", "Firewall disabled", Severity.Critical)
+        }, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].FindingChanges,
+            fc => fc.Type == FindingChangeType.Introduced && fc.Title == "Firewall disabled");
+    }
+
+    [Fact]
+    public void BestWorstScore_Calculated()
+    {
+        _history.SaveAuditResult(MakeReport(50, timestamp: DateTimeOffset.UtcNow.AddHours(-3)));
+        _history.SaveAuditResult(MakeReport(90, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(70, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.Equal(90, report.BestScore);
+        Assert.Equal(50, report.WorstScore);
+    }
+
+    [Fact]
+    public void ImprovementRegressionCounts()
+    {
+        _history.SaveAuditResult(MakeReport(50, timestamp: DateTimeOffset.UtcNow.AddHours(-5)));
+        _history.SaveAuditResult(MakeReport(60, timestamp: DateTimeOffset.UtcNow.AddHours(-4)));
+        _history.SaveAuditResult(MakeReport(55, timestamp: DateTimeOffset.UtcNow.AddHours(-3)));
+        _history.SaveAuditResult(MakeReport(70, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(75, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.Equal(3, report.ImprovementCount);
+        Assert.Equal(1, report.RegressionCount);
+    }
+
+    [Fact]
+    public void MultipleEntries_ChronologicalOrder()
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            _history.SaveAuditResult(MakeReport(50 + i * 10,
+                timestamp: DateTimeOffset.UtcNow.AddHours(-10 + i)));
+        }
+
+        var report = _service.Generate();
+        for (int i = 1; i < report.Entries.Count; i++)
+        {
+            Assert.True(report.Entries[i].Timestamp > report.Entries[i - 1].Timestamp);
+        }
+    }
+
+    [Fact]
+    public void ZeroCritical_Milestone_DetectedInMilestones()
+    {
+        _history.SaveAuditResult(MakeReport(50, criticals: 2, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(80, criticals: 0, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Milestones, m => m.Type == MilestoneType.ZeroCritical);
+    }
+
+    [Fact]
+    public void IsGradeBetter_ComparisonWorks()
+    {
+        Assert.True(SecurityChangelogService.IsGradeBetter("A+", "B"));
+        Assert.True(SecurityChangelogService.IsGradeBetter("B", "C"));
+        Assert.False(SecurityChangelogService.IsGradeBetter("C", "A"));
+        Assert.False(SecurityChangelogService.IsGradeBetter("F", "A+"));
+    }
+
+    [Fact]
+    public void CliParser_Changelog_Parsed()
+    {
+        var opts = CliParser.Parse(new[] { "--changelog" });
+        Assert.Equal(CliCommand.Changelog, opts.Command);
+        Assert.Equal(30, opts.ChangelogDays);
+        Assert.Null(opts.ChangelogModuleFilter);
+    }
+
+    [Fact]
+    public void CliParser_Changelog_WithDays()
+    {
+        var opts = CliParser.Parse(new[] { "--changelog", "--changelog-days", "60" });
+        Assert.Equal(CliCommand.Changelog, opts.Command);
+        Assert.Equal(60, opts.ChangelogDays);
+    }
+
+    [Fact]
+    public void CliParser_Changelog_WithModule()
+    {
+        var opts = CliParser.Parse(new[] { "--changelog", "--changelog-module", "Firewall" });
+        Assert.Equal(CliCommand.Changelog, opts.Command);
+        Assert.Equal("Firewall", opts.ChangelogModuleFilter);
+    }
+
+    [Fact]
+    public void CliParser_ChangelogDays_InvalidValue_Error()
+    {
+        var opts = CliParser.Parse(new[] { "--changelog", "--changelog-days", "0" });
+        Assert.NotNull(opts.Error);
+    }
+
+    [Fact]
+    public void CliParser_ChangelogDays_MissingValue_Error()
+    {
+        var opts = CliParser.Parse(new[] { "--changelog", "--changelog-days" });
+        Assert.NotNull(opts.Error);
+    }
+
+    [Fact]
+    public void CliParser_ChangelogModule_MissingValue_Error()
+    {
+        var opts = CliParser.Parse(new[] { "--changelog", "--changelog-module" });
+        Assert.NotNull(opts.Error);
+    }
+
+    [Fact]
+    public void GradeAchievement_Milestone()
+    {
+        _history.SaveAuditResult(MakeReport(80, timestamp: DateTimeOffset.UtcNow.AddHours(-3)));
+        _history.SaveAuditResult(MakeReport(95, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Milestones, m => m.Type == MilestoneType.GradeAchievement);
+    }
+
+    [Fact]
+    public void FindingChangesOmitted_WhenMoreThanFive()
+    {
+        var findings1 = new List<(string, string, Severity)>();
+        for (int i = 0; i < 8; i++)
+            findings1.Add(("Mod", $"Finding-{i}", Severity.Warning));
+
+        _history.SaveAuditResult(MakeReport(50, findings: findings1,
+            timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(90, findings: new(),
+            timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        var entry = report.Entries[0];
+        Assert.True(entry.FindingChanges.Count <= 5);
+        Assert.True(entry.FindingChangesOmitted > 0);
+    }
+
+    [Fact]
+    public void Report_Period_Set()
+    {
+        var report = _service.Generate(days: 14);
+        Assert.Equal(14, report.Period);
+    }
+
+    [Fact]
+    public void ShortStreak_NoMilestone()
+    {
+        _history.SaveAuditResult(MakeReport(50, timestamp: DateTimeOffset.UtcNow.AddHours(-4)));
+        _history.SaveAuditResult(MakeReport(60, timestamp: DateTimeOffset.UtcNow.AddHours(-3)));
+        _history.SaveAuditResult(MakeReport(70, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(65, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.DoesNotContain(report.Milestones, m => m.Type == MilestoneType.ImprovementStreak);
+    }
+
+    [Fact]
+    public void SmallImprovement_NoBiggestMilestone()
+    {
+        _history.SaveAuditResult(MakeReport(70, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(73, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.DoesNotContain(report.Milestones, m => m.Type == MilestoneType.BiggestImprovement);
+    }
+
+    [Fact]
+    public void WarningIntroduced_Detected()
+    {
+        var t1 = DateTimeOffset.UtcNow.AddHours(-2);
+        var t2 = DateTimeOffset.UtcNow.AddHours(-1);
+        _history.SaveAuditResult(MakeReport(80, warnings: 1, timestamp: t1));
+        _history.SaveAuditResult(MakeReport(70, warnings: 4, timestamp: t2));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].Events,
+            e => e.Type == ChangelogEventType.FindingsIntroduced && e.Summary.Contains("warning"));
+    }
+
+    [Fact]
+    public void GradeDown_Detected()
+    {
+        _history.SaveAuditResult(MakeReport(90, timestamp: DateTimeOffset.UtcNow.AddHours(-2)));
+        _history.SaveAuditResult(MakeReport(60, timestamp: DateTimeOffset.UtcNow.AddHours(-1)));
+
+        var report = _service.Generate();
+        Assert.Contains(report.Entries[0].Events, e => e.Type == ChangelogEventType.GradeDown);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a **SecurityChangelogService** that generates human-readable changelogs from audit history, showing what changed between consecutive scans.

### Features
- 📈📉 **Score tracking** — improvements and regressions between consecutive scans
- ⭐⚠️ **Grade transitions** — detects grade upgrades/downgrades
- ✅🚨 **Finding-level diffs** — specific findings resolved or newly introduced
- 📊 **Module score changes** — per-module score deltas
- 🏆 **Milestone detection** — improvement streaks, perfect scores, first A/A+ grade, biggest single-scan jump, zero-critical achievements
- 🖥️ **CLI integration** — \--changelog\, \--changelog-days N\, \--changelog-module NAME\
- 🎨 **Formatted console output** — color-coded with emoji indicators
- 📋 **JSON output** — via existing \--json\ flag

### CLI Usage
\\\ash
winsentinel --changelog                          # Last 30 days
winsentinel --changelog --changelog-days 60      # Last 60 days
winsentinel --changelog --changelog-module Firewall  # Filter by module
winsentinel --changelog --json                   # JSON output
\\\

### Tests
34 comprehensive tests covering:
- Empty/single scan edge cases
- Score improvement and regression detection
- Grade change detection (up/down)
- Critical and warning finding resolution/introduction
- Milestone detection (streaks, perfect score, zero-critical, biggest jump)
- Day range filtering
- Finding-level diffs (resolved/introduced)
- Finding changes omission (>5 capped)
- CLI parser flag parsing and validation
- Chronological ordering

### Also fixes
- Pre-existing duplicate test method name in InputSanitizerTests