### PR TITLE
feat: add --benchmark CLI command for peer comparison

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -64,6 +64,9 @@ public class CliOptions
     public ExemptionAction ExemptionAction { get; set; } = ExemptionAction.None;
     public int ExemptionWarningDays { get; set; } = 7;
     public int ExemptionStaleDays { get; set; } = 90;
+    public string? BenchmarkGroup { get; set; }
+    public bool BenchmarkAll { get; set; }
+    public bool BenchmarkSuggest { get; set; }
 }
 
 public enum CliCommand
@@ -85,6 +88,7 @@ public enum CliCommand
     Harden,
     Policy,
     Exemptions,
+    Benchmark,
     Help,
     Version
 }
@@ -673,6 +677,32 @@ public static class CliParser
                     {
                         options.Error = "Missing value for --profile (-p). Available: home, developer, enterprise, server";
                         return options;
+                    }
+                    break;
+
+                case "--benchmark":
+                    options.Command = CliCommand.Benchmark;
+                    // Optional: next arg is the peer group (home/developer/enterprise/server)
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith("-"))
+                    {
+                        var groupArg = args[++i].ToLowerInvariant();
+                        if (groupArg == "all")
+                        {
+                            options.BenchmarkAll = true;
+                        }
+                        else if (groupArg == "suggest")
+                        {
+                            options.BenchmarkSuggest = true;
+                        }
+                        else if (groupArg is "home" or "developer" or "enterprise" or "server")
+                        {
+                            options.BenchmarkGroup = groupArg;
+                        }
+                        else
+                        {
+                            options.Error = $"Unknown benchmark group: {groupArg}. Use home, developer, enterprise, server, all, or suggest.";
+                            return options;
+                        }
                     }
                     break;
 

--- a/src/WinSentinel.Cli/ConsoleFormatter.Benchmark.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Benchmark.cs
@@ -1,0 +1,287 @@
+using WinSentinel.Core.Services;
+using static WinSentinel.Core.Services.PeerBenchmarkService;
+
+namespace WinSentinel.Cli;
+
+/// <summary>
+/// Console formatting methods for peer benchmark comparison reports.
+/// </summary>
+public static partial class ConsoleFormatter
+{
+    /// <summary>Print a single peer group benchmark result.</summary>
+    public static void PrintBenchmarkResult(BenchmarkResult result, bool quiet = false)
+    {
+        var orig = Console.ForegroundColor;
+
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("  ╔══════════════════════════════════════════════╗");
+        Console.WriteLine("  ║     📊  Peer Benchmark Comparison           ║");
+        Console.WriteLine("  ╚══════════════════════════════════════════════╝");
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+
+        // Header: group and overall comparison
+        Console.Write("  Peer Group:   ");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine(result.Group);
+        Console.ForegroundColor = orig;
+
+        Console.Write("  Your Score:   ");
+        var scoreColor = result.SystemOverallScore switch
+        {
+            >= 80 => ConsoleColor.Green,
+            >= 60 => ConsoleColor.Yellow,
+            >= 40 => ConsoleColor.DarkYellow,
+            _ => ConsoleColor.Red
+        };
+        Console.ForegroundColor = scoreColor;
+        Console.Write($"{result.SystemOverallScore}/100");
+        Console.ForegroundColor = orig;
+        Console.Write("  |  Peer Median: ");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine($"{result.PeerOverallMedian}/100");
+        Console.ForegroundColor = orig;
+
+        Console.Write("  Percentile:   ");
+        var percColor = result.OverallPercentile switch
+        {
+            >= 75 => ConsoleColor.Green,
+            >= 50 => ConsoleColor.Yellow,
+            >= 25 => ConsoleColor.DarkYellow,
+            _ => ConsoleColor.Red
+        };
+        Console.ForegroundColor = percColor;
+        Console.Write($"{result.OverallPercentile:F0}th");
+        Console.ForegroundColor = orig;
+        Console.Write("  (");
+        Console.ForegroundColor = percColor;
+        Console.Write(result.OverallRating);
+        Console.ForegroundColor = orig;
+        Console.WriteLine(")");
+
+        Console.Write("  Categories:   ");
+        if (result.CategoriesAbovePeer > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.Write($"{result.CategoriesAbovePeer} above");
+        }
+        Console.ForegroundColor = orig;
+        Console.Write("  |  ");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write($"{result.CategoriesAtPeer} at");
+        Console.ForegroundColor = orig;
+        Console.Write("  |  ");
+        if (result.CategoriesBelowPeer > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Write($"{result.CategoriesBelowPeer} below");
+        }
+        else
+        {
+            Console.Write("0 below");
+        }
+        Console.ForegroundColor = orig;
+        Console.WriteLine(" peer");
+        Console.WriteLine();
+
+        if (!quiet)
+        {
+            // Strengths
+            if (result.TopStrengths.Count > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("  STRENGTHS (above peers)");
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine("  ──────────────────────────────────────────");
+                Console.ForegroundColor = orig;
+
+                foreach (var s in result.TopStrengths)
+                {
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.Write($"  + {s.Category,-20}");
+                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.Write($"{s.SystemScore,4}");
+                    Console.ForegroundColor = orig;
+                    Console.Write($" vs {s.PeerMedian,3} median  ");
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.Write($"(+{s.Delta})");
+                    Console.ForegroundColor = ConsoleColor.DarkGray;
+                    Console.WriteLine($"  {s.Percentile:F0}th pctl");
+                    Console.ForegroundColor = orig;
+                }
+                Console.WriteLine();
+            }
+
+            // Weaknesses
+            if (result.TopWeaknesses.Count > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine("  WEAKNESSES (below peers)");
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine("  ──────────────────────────────────────────");
+                Console.ForegroundColor = orig;
+
+                foreach (var w in result.TopWeaknesses)
+                {
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.Write($"  - {w.Category,-20}");
+                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.Write($"{w.SystemScore,4}");
+                    Console.ForegroundColor = orig;
+                    Console.Write($" vs {w.PeerMedian,3} median  ");
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.Write($"({w.Delta})");
+                    Console.ForegroundColor = ConsoleColor.DarkGray;
+                    Console.WriteLine($"  {w.Percentile:F0}th pctl");
+                    Console.ForegroundColor = orig;
+                }
+                Console.WriteLine();
+            }
+
+            // Category table
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.WriteLine("  ALL CATEGORIES");
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine("  ──────────────────────────────────────────────────────────────");
+            Console.ForegroundColor = orig;
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"  {"Category",-20} {"Score",5} {"Median",7} {"P25",5} {"P75",5} {"Delta",6} {"Pctl",5}  Rating");
+            Console.ForegroundColor = orig;
+
+            foreach (var c in result.Categories)
+            {
+                var ratingColor = c.Rating switch
+                {
+                    ComparisonRating.WellAbovePeer => ConsoleColor.Green,
+                    ComparisonRating.AbovePeer => ConsoleColor.Green,
+                    ComparisonRating.AtPeer => ConsoleColor.White,
+                    ComparisonRating.BelowPeer => ConsoleColor.Yellow,
+                    ComparisonRating.WellBelowPeer => ConsoleColor.Red,
+                    _ => orig
+                };
+
+                Console.Write($"  {c.Category,-20}");
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write($"{c.SystemScore,5}");
+                Console.ForegroundColor = orig;
+                Console.Write($"{c.PeerMedian,7}{c.PeerP25,5}{c.PeerP75,5}");
+
+                Console.ForegroundColor = ratingColor;
+                var deltaStr = c.Delta >= 0 ? $"+{c.Delta}" : c.Delta.ToString();
+                Console.Write($"{deltaStr,6}");
+                Console.ForegroundColor = orig;
+                Console.Write($"{c.Percentile,5:F0}");
+                Console.Write("  ");
+                Console.ForegroundColor = ratingColor;
+                Console.WriteLine(FormatRating(c.Rating));
+                Console.ForegroundColor = orig;
+            }
+            Console.WriteLine();
+
+            // Suggestions
+            if (result.Suggestions.Count > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                Console.WriteLine("  IMPROVEMENT SUGGESTIONS");
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine("  ──────────────────────────────────────────");
+                Console.ForegroundColor = orig;
+
+                foreach (var sug in result.Suggestions.Take(10))
+                {
+                    var prioColor = sug.Priority switch
+                    {
+                        ImprovementPriority.Critical => ConsoleColor.Red,
+                        ImprovementPriority.High => ConsoleColor.DarkYellow,
+                        ImprovementPriority.Medium => ConsoleColor.Yellow,
+                        _ => ConsoleColor.Gray
+                    };
+
+                    Console.ForegroundColor = prioColor;
+                    Console.Write($"  [{sug.Priority}] ");
+                    Console.ForegroundColor = ConsoleColor.White;
+                    Console.Write($"{sug.Category}");
+                    Console.ForegroundColor = orig;
+                    Console.WriteLine($" (gap: {sug.Gap} pts)");
+                    Console.ForegroundColor = ConsoleColor.DarkCyan;
+                    Console.WriteLine($"    → {sug.Recommendation}");
+                    Console.ForegroundColor = orig;
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+
+    /// <summary>Print a summary comparison across all peer groups.</summary>
+    public static void PrintBenchmarkAllResults(Dictionary<PeerGroup, BenchmarkResult> results, bool quiet = false)
+    {
+        var orig = Console.ForegroundColor;
+
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("  ╔══════════════════════════════════════════════╗");
+        Console.WriteLine("  ║     📊  Peer Benchmark — All Groups         ║");
+        Console.WriteLine("  ╚══════════════════════════════════════════════╝");
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine($"  {"Peer Group",-14} {"Score",5} {"Median",7} {"Pctl",6}  {"Above",6} {"At",4} {"Below",6}  Rating");
+        Console.WriteLine($"  {"──────────────",-14} {"─────",5} {"───────",7} {"──────",6}  {"──────",6} {"────",4} {"──────",6}  ────────────────────────");
+        Console.ForegroundColor = orig;
+
+        foreach (var (group, result) in results.OrderBy(kv => kv.Key))
+        {
+            var percColor = result.OverallPercentile switch
+            {
+                >= 75 => ConsoleColor.Green,
+                >= 50 => ConsoleColor.Yellow,
+                >= 25 => ConsoleColor.DarkYellow,
+                _ => ConsoleColor.Red
+            };
+
+            Console.Write($"  {group,-14}");
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.Write($"{result.SystemOverallScore,5}");
+            Console.ForegroundColor = orig;
+            Console.Write($"{result.PeerOverallMedian,7}");
+            Console.ForegroundColor = percColor;
+            Console.Write($"{result.OverallPercentile,5:F0}th");
+            Console.ForegroundColor = orig;
+            Console.Write($"  ");
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.Write($"{result.CategoriesAbovePeer,6}");
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.Write($"{result.CategoriesAtPeer,4}");
+            Console.ForegroundColor = result.CategoriesBelowPeer > 0 ? ConsoleColor.Red : orig;
+            Console.Write($"{result.CategoriesBelowPeer,6}");
+            Console.ForegroundColor = orig;
+            Console.Write("  ");
+            Console.ForegroundColor = percColor;
+            Console.WriteLine(result.OverallRating);
+            Console.ForegroundColor = orig;
+        }
+
+        Console.WriteLine();
+
+        if (!quiet)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine("  Tip: Run 'winsentinel --benchmark <group>' for detailed comparison.");
+            Console.WriteLine("       Run 'winsentinel --benchmark suggest' to find your best-fit group.");
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+        }
+    }
+
+    private static string FormatRating(ComparisonRating rating) => rating switch
+    {
+        ComparisonRating.WellAbovePeer => "Well Above",
+        ComparisonRating.AbovePeer => "Above",
+        ComparisonRating.AtPeer => "At Peer",
+        ComparisonRating.BelowPeer => "Below",
+        ComparisonRating.WellBelowPeer => "Well Below",
+        _ => rating.ToString()
+    };
+}

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -304,6 +304,10 @@ public static partial class ConsoleFormatter
         Console.ForegroundColor = original;
         Console.WriteLine("Quick security posture dashboard (no new scan)");
         Console.ForegroundColor = ConsoleColor.White;
+        Console.Write("    --benchmark [group]  ");
+        Console.ForegroundColor = original;
+        Console.WriteLine("Compare against peers (home/developer/enterprise/server/all/suggest)");
+        Console.ForegroundColor = ConsoleColor.White;
         Console.Write("    --harden             ");
         Console.ForegroundColor = original;
         Console.WriteLine("Generate reviewable PowerShell hardening script");

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -36,6 +36,7 @@ return options.Command switch
     CliCommand.Harden => await HandleHarden(options),
     CliCommand.Policy => HandlePolicy(options),
     CliCommand.Exemptions => HandleExemptions(options),
+    CliCommand.Benchmark => await HandleBenchmark(options),
     _ => HandleHelp()
 };
 
@@ -2491,3 +2492,174 @@ static object FormatReviewedRuleJson(ExemptionReviewService.ReviewedRule r)
         recommendation = r.Recommendation
     };
 }
+
+// ── Peer Benchmark ───────────────────────────────────────────────────
+
+static async Task<int> HandleBenchmark(CliOptions options)
+{
+    var engine = BuildEngine(options.ModulesFilter);
+    var sw = Stopwatch.StartNew();
+
+    if (!options.Quiet)
+    {
+        ConsoleFormatter.PrintBanner();
+        Console.WriteLine("  Running audit for peer benchmark comparison...");
+        Console.WriteLine();
+    }
+
+    var progress = options.Quiet
+        ? null
+        : new Progress<(string module, int current, int total)>(p =>
+            ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
+
+    var report = await engine.RunFullAuditAsync(progress);
+    sw.Stop();
+
+    if (!options.Quiet)
+    {
+        ConsoleFormatter.PrintProgressDone(engine.Modules.Count, sw.Elapsed);
+        ConsoleFormatter.PrintScore(report.SecurityScore);
+    }
+
+    var benchmarkService = new PeerBenchmarkService();
+
+    // Handle "suggest" mode — find best peer group
+    if (options.BenchmarkSuggest)
+    {
+        var suggested = benchmarkService.SuggestPeerGroup(report);
+        if (options.Json)
+        {
+            var jsonOptions = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+            var suggestObj = new
+            {
+                suggestedGroup = suggested.ToString(),
+                systemScore = report.SecurityScore,
+                rationale = $"Your score of {report.SecurityScore} is closest to the {suggested} peer group median"
+            };
+            var json = JsonSerializer.Serialize(suggestObj, jsonOptions);
+            WriteOutput(json, options.OutputFile);
+        }
+        else
+        {
+            Console.WriteLine();
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.Write("  Suggested peer group: ");
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.WriteLine(suggested);
+            Console.ResetColor();
+            Console.WriteLine($"  Based on your system score of {report.SecurityScore}/100");
+            Console.WriteLine();
+            Console.WriteLine("  Run with that group:");
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"    winsentinel --benchmark {suggested.ToString().ToLowerInvariant()}");
+            Console.ResetColor();
+            Console.WriteLine();
+        }
+        return 0;
+    }
+
+    // Handle "all" mode — compare against all peer groups
+    if (options.BenchmarkAll)
+    {
+        var allResults = benchmarkService.CompareAll(report);
+
+        if (options.Json)
+        {
+            var jsonOptions = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+            var allObj = allResults.ToDictionary(
+                kv => kv.Key.ToString(),
+                kv => FormatBenchmarkResultJson(kv.Value));
+            var json = JsonSerializer.Serialize(allObj, jsonOptions);
+            WriteOutput(json, options.OutputFile);
+        }
+        else
+        {
+            ConsoleFormatter.PrintBenchmarkAllResults(allResults, options.Quiet);
+        }
+        return 0;
+    }
+
+    // Single peer group comparison (default to auto-suggested group)
+    var peerGroup = PeerBenchmarkService.PeerGroup.Home;
+    if (options.BenchmarkGroup != null)
+    {
+        peerGroup = options.BenchmarkGroup.ToLowerInvariant() switch
+        {
+            "home" => PeerBenchmarkService.PeerGroup.Home,
+            "developer" => PeerBenchmarkService.PeerGroup.Developer,
+            "enterprise" => PeerBenchmarkService.PeerGroup.Enterprise,
+            "server" => PeerBenchmarkService.PeerGroup.Server,
+            _ => PeerBenchmarkService.PeerGroup.Home
+        };
+    }
+    else
+    {
+        // Auto-suggest best group
+        peerGroup = benchmarkService.SuggestPeerGroup(report);
+    }
+
+    var result = benchmarkService.Compare(report, peerGroup);
+
+    if (options.Json)
+    {
+        var jsonOptions = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+        var json = JsonSerializer.Serialize(FormatBenchmarkResultJson(result), jsonOptions);
+        WriteOutput(json, options.OutputFile);
+    }
+    else
+    {
+        ConsoleFormatter.PrintBenchmarkResult(result, options.Quiet);
+    }
+
+    return 0;
+}
+
+static object FormatBenchmarkResultJson(PeerBenchmarkService.BenchmarkResult result) => new
+{
+    peerGroup = result.Group.ToString(),
+    systemScore = result.SystemOverallScore,
+    peerMedian = result.PeerOverallMedian,
+    overallPercentile = Math.Round(result.OverallPercentile, 1),
+    overallRating = result.OverallRating,
+    categoriesAbovePeer = result.CategoriesAbovePeer,
+    categoriesAtPeer = result.CategoriesAtPeer,
+    categoriesBelowPeer = result.CategoriesBelowPeer,
+    strengths = result.TopStrengths.Select(s => new
+    {
+        category = s.Category,
+        systemScore = s.SystemScore,
+        peerMedian = s.PeerMedian,
+        delta = s.Delta,
+        percentile = Math.Round(s.Percentile, 1),
+        rating = s.Rating.ToString()
+    }),
+    weaknesses = result.TopWeaknesses.Select(w => new
+    {
+        category = w.Category,
+        systemScore = w.SystemScore,
+        peerMedian = w.PeerMedian,
+        delta = w.Delta,
+        percentile = Math.Round(w.Percentile, 1),
+        rating = w.Rating.ToString()
+    }),
+    categories = result.Categories.Select(c => new
+    {
+        category = c.Category,
+        systemScore = c.SystemScore,
+        peerMedian = c.PeerMedian,
+        peerP25 = c.PeerP25,
+        peerP75 = c.PeerP75,
+        delta = c.Delta,
+        percentile = Math.Round(c.Percentile, 1),
+        rating = c.Rating.ToString()
+    }),
+    suggestions = result.Suggestions.Select(s => new
+    {
+        category = s.Category,
+        currentScore = s.CurrentScore,
+        peerMedian = s.PeerMedian,
+        gap = s.Gap,
+        recommendation = s.Recommendation,
+        priority = s.Priority.ToString()
+    })
+};

--- a/tests/WinSentinel.Tests/Cli/CliParserTests.cs
+++ b/tests/WinSentinel.Tests/Cli/CliParserTests.cs
@@ -1164,4 +1164,80 @@ public class CliParserTests
         Assert.Equal(BadgeBadgeAction.None, options.BadgeAction);
         Assert.Null(options.BadgeStyle);
     }
+
+    // ── Benchmark ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_Benchmark_NoGroup_DefaultsToCommand()
+    {
+        var result = CliParser.Parse(["--benchmark"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Null(result.BenchmarkGroup);
+        Assert.False(result.BenchmarkAll);
+        Assert.False(result.BenchmarkSuggest);
+        Assert.Null(result.Error);
+    }
+
+    [Theory]
+    [InlineData("home")]
+    [InlineData("developer")]
+    [InlineData("enterprise")]
+    [InlineData("server")]
+    public void Parse_Benchmark_ValidGroup(string group)
+    {
+        var result = CliParser.Parse(["--benchmark", group]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Equal(group, result.BenchmarkGroup);
+        Assert.False(result.BenchmarkAll);
+        Assert.False(result.BenchmarkSuggest);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_All()
+    {
+        var result = CliParser.Parse(["--benchmark", "all"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.True(result.BenchmarkAll);
+        Assert.Null(result.BenchmarkGroup);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_Suggest()
+    {
+        var result = CliParser.Parse(["--benchmark", "suggest"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.True(result.BenchmarkSuggest);
+        Assert.Null(result.BenchmarkGroup);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_InvalidGroup_ReturnsError()
+    {
+        var result = CliParser.Parse(["--benchmark", "invalid"]);
+        Assert.NotNull(result.Error);
+        Assert.Contains("Unknown benchmark group", result.Error);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_WithJson()
+    {
+        var result = CliParser.Parse(["--benchmark", "developer", "--json"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Equal("developer", result.BenchmarkGroup);
+        Assert.True(result.Json);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_WithModulesFilter()
+    {
+        var result = CliParser.Parse(["--benchmark", "home", "--modules", "firewall,network"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Equal("home", result.BenchmarkGroup);
+        Assert.Equal("firewall,network", result.ModulesFilter);
+        Assert.Null(result.Error);
+    }
 }


### PR DESCRIPTION
## Summary

Exposes the existing \PeerBenchmarkService\ through the CLI, allowing users to compare their system's security posture against peer groups directly from the command line.

## New CLI Commands

| Command | Description |
|---------|-------------|
| \--benchmark\ | Compare against auto-detected best-fit peer group |
| \--benchmark home\ | Compare against home user peers |
| \--benchmark developer\ | Compare against developer peers |
| \--benchmark enterprise\ | Compare against enterprise peers |
| \--benchmark server\ | Compare against server peers |
| \--benchmark all\ | Side-by-side comparison across all 4 groups |
| \--benchmark suggest\ | Auto-detect which peer group fits your score |

## Options

- \--json\ — Machine-readable JSON output
- \--modules <list>\ — Filter which audit modules to run
- \--quiet\ — Minimal output (header only, no category table)
- \-o <file>\ — Save output to file

## Console Output

Rich color-coded output including:
- Overall score vs peer median with percentile ranking
- Top strengths (categories above peers) in green
- Top weaknesses (categories below peers) in red
- Full category comparison table with P25/P75 ranges
- Prioritized improvement suggestions with gap analysis

## Files Changed

- \CliParser.cs\ — Added \Benchmark\ command enum + parsing logic
- \Program.cs\ — Added \HandleBenchmark()\ with JSON/console output
- \ConsoleFormatter.Benchmark.cs\ — New partial class with print methods
- \ConsoleFormatter.cs\ — Added help text entry
- \CliParserTests.cs\ — 8 new tests for benchmark argument parsing

## Testing

All 153 CLI parser tests pass. Build succeeds with 0 errors.