### PR TITLE
fix: InputSanitizer recursive delete check missed Remove-Item without trailing slash

### DIFF
--- a/src/WinSentinel.Core/Helpers/InputSanitizer.cs
+++ b/src/WinSentinel.Core/Helpers/InputSanitizer.cs
@@ -254,7 +254,7 @@ public static partial class InputSanitizer
         // Destructive commands
         if (lower.Contains("format ") && lower.Contains("/y"))
             return "Contains destructive format command";
-        if (lower.Contains("del /s /q") || lower.Contains("remove-item -recurse -force /"))
+        if (lower.Contains("del /s /q") || lower.Contains("remove-item -recurse -force"))
             return "Contains recursive delete command";
 
         // Network exfiltration

--- a/tests/WinSentinel.Tests/InputSanitizerTests.cs
+++ b/tests/WinSentinel.Tests/InputSanitizerTests.cs
@@ -226,6 +226,7 @@ public class InputSanitizerTests
     [Theory]
     [InlineData("format C: /y", "destructive format")]
     [InlineData("del /s /q C:\\*", "recursive delete")]
+    [InlineData("Remove-Item -Recurse -Force C:\\Users\\temp", "recursive delete")]
     public void CheckDangerousCommand_DestructiveCommands_ReturnsReason(string input, string reasonContains)
     {
         var result = InputSanitizer.CheckDangerousCommand(input);


### PR DESCRIPTION
## Summary

\CheckDangerousCommand\ in \InputSanitizer\ checked for the string \emove-item -recurse -force /\ (with a trailing forward slash). This meant it would only match commands containing a Unix-style forward slash after \-Force\, missing the common Windows usage like:

\\\powershell
Remove-Item -Recurse -Force C:\Users\temp\data
\\\

## Fix

Removed the trailing \/\ from the pattern so it matches any \Remove-Item -Recurse -Force\ command regardless of what follows.

## Test

Added an \InlineData\ test case for \Remove-Item -Recurse -Force C:\Users\temp\ to the destructive commands test.