### PR TITLE
feat: SecurityMetricsAggregator -- operational security KPIs with CLI --metrics command (35 tests)

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -72,6 +72,9 @@ public class CliOptions
     public int RootCauseTop { get; set; } = 10;
     public string? RootCauseSeverityFilter { get; set; }
     public int ScheduleOptimizeDays { get; set; } = 90;
+    public int MetricsDays { get; set; } = 90;
+    public int MetricsWindows { get; set; } = 6;
+    public int MetricsTopRecurring { get; set; } = 10;
 }
 
 public enum CliCommand
@@ -97,6 +100,7 @@ public enum CliCommand
     RootCause,
     Threats,
     ScheduleOptimize,
+    Metrics,
     Help,
     Version
 }
@@ -426,6 +430,25 @@ public static class CliParser
 
                 case "--schedule-optimize":
                     options.Command = CliCommand.ScheduleOptimize;
+                    break;
+
+                case "--metrics":
+                    options.Command = CliCommand.Metrics;
+                    break;
+
+                case "--metrics-days":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var metricsDays))
+                        options.MetricsDays = metricsDays;
+                    break;
+
+                case "--metrics-windows":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var metricsWindows))
+                        options.MetricsWindows = metricsWindows;
+                    break;
+
+                case "--metrics-top":
+                    if (i + 1 < args.Length && int.TryParse(args[++i], out var metricsTop))
+                        options.MetricsTopRecurring = metricsTop;
                     break;
 
                 case "export" when options.Command == CliCommand.Policy:

--- a/src/WinSentinel.Cli/ConsoleFormatter.Metrics.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Metrics.cs
@@ -1,0 +1,150 @@
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Cli;
+
+/// <summary>
+/// Console formatting for security metrics output.
+/// </summary>
+public static partial class ConsoleFormatter
+{
+    public static void PrintMetricsReport(SecurityMetricsAggregator.MetricsReport report)
+    {
+        if (report.RunsAnalyzed == 0)
+        {
+            PrintWarning("No audit history found. Run some audits first.");
+            return;
+        }
+
+        WriteLineColored("", ConsoleColor.Cyan);
+        WriteLineColored("  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+        WriteLineColored("  ║       Security Metrics Dashboard            ║", ConsoleColor.Cyan);
+        WriteLineColored("  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        // Health grade
+        var gradeColor = report.HealthGrade switch
+        {
+            "A" => ConsoleColor.Green,
+            "B" => ConsoleColor.Green,
+            "C" => ConsoleColor.Yellow,
+            "D" => ConsoleColor.Red,
+            _ => ConsoleColor.DarkRed
+        };
+
+        WriteColored("  Health Grade: ", ConsoleColor.White);
+        WriteColored(report.HealthGrade, gradeColor);
+        WriteLineColored($" ({report.HealthScore:F1}/100)", ConsoleColor.Gray);
+        Console.WriteLine();
+
+        // Analysis period
+        WriteLineColored($"  Analyzed {report.RunsAnalyzed} runs over {report.AnalysisPeriod.TotalDays:F0} days", ConsoleColor.Gray);
+        if (report.FirstRun.HasValue)
+            WriteLineColored($"  Period: {report.FirstRun.Value:yyyy-MM-dd} → {report.LastRun!.Value:yyyy-MM-dd}", ConsoleColor.Gray);
+        Console.WriteLine();
+
+        // KPIs
+        WriteLineColored("  ── Key Performance Indicators ──────────────────", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        PrintKpiRow("MTTR (Mean Time to Resolve)", FormatDuration(report.MttrHours),
+            report.MttrHours <= 24 ? ConsoleColor.Green : report.MttrHours <= 72 ? ConsoleColor.Yellow : ConsoleColor.Red);
+        PrintKpiRow("MTTD (Mean Time to Detect)", FormatDuration(report.MttdHours),
+            report.MttdHours <= 24 ? ConsoleColor.Green : report.MttdHours <= 48 ? ConsoleColor.Yellow : ConsoleColor.Red);
+        PrintKpiRow("Finding Velocity", $"{report.FindingVelocityPerDay:F2}/day introduced", ConsoleColor.White);
+        PrintKpiRow("Resolution Velocity", $"{report.ResolutionVelocityPerDay:F2}/day resolved", ConsoleColor.White);
+        PrintKpiRow("Resolution Efficiency", $"{report.ResolutionEfficiency:P1}",
+            report.ResolutionEfficiency >= 1.0 ? ConsoleColor.Green : report.ResolutionEfficiency >= 0.8 ? ConsoleColor.Yellow : ConsoleColor.Red);
+        PrintKpiRow("Recurrence Rate", $"{report.RecurrenceRatePercent:F1}%",
+            report.RecurrenceRatePercent <= 10 ? ConsoleColor.Green : report.RecurrenceRatePercent <= 25 ? ConsoleColor.Yellow : ConsoleColor.Red);
+        Console.WriteLine();
+
+        // Current state
+        WriteLineColored("  ── Current State ──────────────────────────────", ConsoleColor.Cyan);
+        Console.WriteLine();
+        WriteLineColored($"  Open Findings: {report.CurrentlyOpen}  |  Unique Seen: {report.TotalUnique}  |  Resolved: {report.TotalResolved}  |  Recurrent: {report.TotalRecurrent}", ConsoleColor.White);
+
+        if (report.CurrentSeverity.Total > 0)
+        {
+            Console.Write("  Severity: ");
+            if (report.CurrentSeverity.Critical > 0)
+                WriteColored($"■ {report.CurrentSeverity.Critical} Critical  ", ConsoleColor.Red);
+            if (report.CurrentSeverity.Warning > 0)
+                WriteColored($"■ {report.CurrentSeverity.Warning} Warning  ", ConsoleColor.Yellow);
+            if (report.CurrentSeverity.Info > 0)
+                WriteColored($"■ {report.CurrentSeverity.Info} Info", ConsoleColor.Cyan);
+            Console.WriteLine();
+        }
+        Console.WriteLine();
+
+        // Module health
+        if (report.Modules.Count > 0)
+        {
+            WriteLineColored("  ── Module Health ──────────────────────────────", ConsoleColor.Cyan);
+            Console.WriteLine();
+            WriteLineColored("  Module                    Current  Peak  Avg   Introduced  Resolved  MTTR       Grade", ConsoleColor.Gray);
+            WriteLineColored("  ─────────────────────────────────────────────────────────────────────────────────────", ConsoleColor.DarkGray);
+
+            foreach (var m in report.Modules)
+            {
+                var modGradeColor = m.HealthGrade switch
+                {
+                    "A" => ConsoleColor.Green,
+                    "B" => ConsoleColor.Green,
+                    "C" => ConsoleColor.Yellow,
+                    "D" => ConsoleColor.Red,
+                    _ => ConsoleColor.DarkRed
+                };
+
+                Console.Write($"  {m.ModuleName,-26} {m.CurrentFindings,7}  {m.PeakFindings,4}  {m.AvgFindings,4:F1}   {m.TotalIntroduced,10}  {m.TotalResolved,8}  {FormatDuration(m.MttrHours),-9}  ");
+                WriteLineColored(m.HealthGrade, modGradeColor);
+            }
+            Console.WriteLine();
+        }
+
+        // Top recurring
+        if (report.TopRecurring.Count > 0)
+        {
+            WriteLineColored("  ── Top Recurring Findings ─────────────────────", ConsoleColor.Cyan);
+            Console.WriteLine();
+
+            foreach (var r in report.TopRecurring)
+            {
+                var sevColor = r.Severity.Equals("Critical", StringComparison.OrdinalIgnoreCase) ? ConsoleColor.Red : ConsoleColor.Yellow;
+                WriteColored($"  [{r.Severity}] ", sevColor);
+                WriteLineColored($"{r.Title} ({r.ModuleName}) — {r.Recurrences} recurrence(s), avg {r.AvgDaysBeforeRecurrence:F1} days between", ConsoleColor.White);
+            }
+            Console.WriteLine();
+        }
+
+        // Severity trend
+        if (report.SeverityTrend.Count > 0)
+        {
+            WriteLineColored("  ── Severity Trend ─────────────────────────────", ConsoleColor.Cyan);
+            Console.WriteLine();
+
+            foreach (var pt in report.SeverityTrend)
+            {
+                Console.Write($"  {pt.WindowStart:MM/dd} → {pt.WindowEnd:MM/dd}  Score:{pt.OverallScore,3}  ");
+                if (pt.Severity.Critical > 0) WriteColored($"C:{pt.Severity.Critical} ", ConsoleColor.Red);
+                if (pt.Severity.Warning > 0) WriteColored($"W:{pt.Severity.Warning} ", ConsoleColor.Yellow);
+                if (pt.Severity.Info > 0) WriteColored($"I:{pt.Severity.Info} ", ConsoleColor.Cyan);
+                Console.WriteLine();
+            }
+            Console.WriteLine();
+        }
+    }
+
+    private static void PrintKpiRow(string label, string value, ConsoleColor valueColor)
+    {
+        WriteColored($"  {label,-32} ", ConsoleColor.White);
+        WriteLineColored(value, valueColor);
+    }
+
+    private static string FormatDuration(double hours) => hours switch
+    {
+        0 => "N/A",
+        < 1 => $"{hours * 60:F0}m",
+        < 24 => $"{hours:F1}h",
+        _ => $"{hours / 24:F1}d"
+    };
+}

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -40,6 +40,7 @@ return options.Command switch
     CliCommand.RootCause => await HandleRootCause(options),
     CliCommand.Threats => await HandleThreats(options),
     CliCommand.ScheduleOptimize => HandleScheduleOptimize(options),
+    CliCommand.Metrics => HandleMetrics(options),
     _ => HandleHelp()
 };
 
@@ -2411,5 +2412,31 @@ static int HandleScheduleOptimize(CliOptions options)
     }
 
     ConsoleFormatter.PrintScheduleOptimizeResult(result);
+    return 0;
+}
+
+// ── Security Metrics ──────────────────────────────────────────────
+
+static int HandleMetrics(CliOptions options)
+{
+    ConsoleFormatter.PrintBanner();
+
+    using var history = new AuditHistoryService();
+    var runs = history.GetHistory(options.MetricsDays);
+    var aggregator = new SecurityMetricsAggregator();
+    var report = aggregator.Analyze(runs, options.MetricsWindows, options.MetricsTopRecurring);
+
+    if (options.Json)
+    {
+        var jsonOpts = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        Console.WriteLine(JsonSerializer.Serialize(report, jsonOpts));
+        return 0;
+    }
+
+    ConsoleFormatter.PrintMetricsReport(report);
     return 0;
 }

--- a/src/WinSentinel.Core/Services/SecurityMetricsAggregator.cs
+++ b/src/WinSentinel.Core/Services/SecurityMetricsAggregator.cs
@@ -1,0 +1,400 @@
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+/// <summary>
+/// Computes operational security KPIs from audit history: MTTR, finding velocity,
+/// recurrence rate, resolution efficiency, severity breakdown trends, and module
+/// health scores. Provides actionable metrics for security operations teams.
+/// </summary>
+public class SecurityMetricsAggregator
+{
+    // ── Public types ─────────────────────────────────────────────────
+
+    /// <summary>Overall security metrics report.</summary>
+    public class MetricsReport
+    {
+        public int RunsAnalyzed { get; init; }
+        public TimeSpan AnalysisPeriod { get; init; }
+        public DateTimeOffset? FirstRun { get; init; }
+        public DateTimeOffset? LastRun { get; init; }
+        public double MttrHours { get; init; }
+        public double MttdHours { get; init; }
+        public double FindingVelocityPerDay { get; init; }
+        public double ResolutionVelocityPerDay { get; init; }
+        public double ResolutionEfficiency { get; init; }
+        public double RecurrenceRatePercent { get; init; }
+        public int TotalUnique { get; init; }
+        public int CurrentlyOpen { get; init; }
+        public int TotalResolved { get; init; }
+        public int TotalRecurrent { get; init; }
+        public SeverityBreakdown CurrentSeverity { get; init; } = new();
+        public List<SeverityTrendPoint> SeverityTrend { get; init; } = [];
+        public List<ModuleHealth> Modules { get; init; } = [];
+        public List<RecurringFinding> TopRecurring { get; init; } = [];
+        public string HealthGrade { get; init; } = "";
+        public double HealthScore { get; init; }
+        public string Summary { get; init; } = "";
+    }
+
+    public record SeverityBreakdown
+    {
+        public int Critical { get; init; }
+        public int Warning { get; init; }
+        public int Info { get; init; }
+        public int Total => Critical + Warning + Info;
+    }
+
+    public record SeverityTrendPoint(
+        DateTimeOffset WindowStart, DateTimeOffset WindowEnd,
+        int RunCount, SeverityBreakdown Severity, int OverallScore);
+
+    public record ModuleHealth(
+        string ModuleName, string Category,
+        int CurrentFindings, int PeakFindings, double AvgFindings,
+        int TotalIntroduced, int TotalResolved,
+        double MttrHours, double RecurrenceRatePercent, string HealthGrade);
+
+    public record RecurringFinding(
+        string ModuleName, string Title, string Severity,
+        int Occurrences, int Recurrences, double AvgDaysBeforeRecurrence);
+
+    // ── Core analysis ────────────────────────────────────────────────
+
+    public MetricsReport Analyze(
+        IReadOnlyList<AuditRunRecord> runs,
+        int windowCount = 6,
+        int topRecurringCount = 10)
+    {
+        if (runs == null) throw new ArgumentNullException(nameof(runs));
+
+        if (runs.Count == 0)
+            return new MetricsReport
+            {
+                RunsAnalyzed = 0, AnalysisPeriod = TimeSpan.Zero,
+                HealthGrade = "N/A",
+                Summary = "No audit runs available for analysis."
+            };
+
+        var sorted = runs.OrderBy(r => r.Timestamp).ToList();
+        var first = sorted[0].Timestamp;
+        var last = sorted[^1].Timestamp;
+        var period = last - first;
+
+        var lifecycles = TrackLifecycles(sorted);
+
+        double mttrHours = 0;
+        var allResolutions = lifecycles.Values.SelectMany(l => l.Resolutions).ToList();
+        if (allResolutions.Count > 0)
+            mttrHours = allResolutions.Average(r => r.TotalHours);
+
+        double mttdHours = 0;
+        if (sorted.Count > 1)
+        {
+            var gaps = new List<double>();
+            for (int i = 1; i < sorted.Count; i++)
+                gaps.Add((sorted[i].Timestamp - sorted[i - 1].Timestamp).TotalHours);
+            mttdHours = gaps.Average();
+        }
+
+        int totalIntroduced = lifecycles.Values.Sum(l => l.IntroducedCount);
+        int totalResolved = lifecycles.Values.Sum(l => l.Resolutions.Count);
+        double days = Math.Max(period.TotalDays, 1);
+        double findingVelocity = totalIntroduced / days;
+        double resolutionVelocity = totalResolved / days;
+        double resolutionEfficiency = totalIntroduced > 0
+            ? (double)totalResolved / totalIntroduced : 1.0;
+
+        var recurrentFindings = lifecycles.Values.Where(l => l.Recurrences > 0).ToList();
+        int totalRecurrent = recurrentFindings.Count;
+        double recurrenceRate = totalResolved > 0
+            ? (double)totalRecurrent / totalResolved * 100 : 0;
+
+        var latestFindings = sorted[^1].Findings
+            .Where(f => !f.Severity.Equals("Pass", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        var currentSeverity = new SeverityBreakdown
+        {
+            Critical = latestFindings.Count(f => f.Severity.Equals("Critical", StringComparison.OrdinalIgnoreCase)),
+            Warning = latestFindings.Count(f => f.Severity.Equals("Warning", StringComparison.OrdinalIgnoreCase)),
+            Info = latestFindings.Count(f => f.Severity.Equals("Info", StringComparison.OrdinalIgnoreCase))
+        };
+
+        var severityTrend = ComputeSeverityTrend(sorted, windowCount);
+        var moduleHealth = ComputeModuleHealth(sorted, lifecycles);
+
+        var topRecurring = recurrentFindings
+            .OrderByDescending(l => l.Recurrences)
+            .ThenByDescending(l => l.LastSeverity.Equals("Critical", StringComparison.OrdinalIgnoreCase) ? 1 : 0)
+            .Take(topRecurringCount)
+            .Select(l => new RecurringFinding(
+                l.ModuleName, l.Title, l.LastSeverity,
+                l.IntroducedCount, l.Recurrences,
+                l.RecurrenceGaps.Count > 0 ? l.RecurrenceGaps.Average(g => g.TotalDays) : 0))
+            .ToList();
+
+        double healthScore = ComputeHealthScore(mttrHours, recurrenceRate, currentSeverity, resolutionEfficiency);
+        string healthGrade = ScoreToGrade(healthScore);
+
+        string summary = BuildSummary(sorted.Count, period, mttrHours, mttdHours,
+            findingVelocity, resolutionVelocity, resolutionEfficiency,
+            recurrenceRate, latestFindings.Count, currentSeverity, healthGrade, healthScore);
+
+        return new MetricsReport
+        {
+            RunsAnalyzed = sorted.Count, AnalysisPeriod = period,
+            FirstRun = first, LastRun = last,
+            MttrHours = Math.Round(mttrHours, 2),
+            MttdHours = Math.Round(mttdHours, 2),
+            FindingVelocityPerDay = Math.Round(findingVelocity, 2),
+            ResolutionVelocityPerDay = Math.Round(resolutionVelocity, 2),
+            ResolutionEfficiency = Math.Round(resolutionEfficiency, 3),
+            RecurrenceRatePercent = Math.Round(recurrenceRate, 1),
+            TotalUnique = lifecycles.Count,
+            CurrentlyOpen = latestFindings.Count,
+            TotalResolved = totalResolved,
+            TotalRecurrent = totalRecurrent,
+            CurrentSeverity = currentSeverity,
+            SeverityTrend = severityTrend,
+            Modules = moduleHealth,
+            TopRecurring = topRecurring,
+            HealthGrade = healthGrade,
+            HealthScore = Math.Round(healthScore, 1),
+            Summary = summary
+        };
+    }
+
+    // ── Finding lifecycle tracking ───────────────────────────────────
+
+    private class FindingLifecycle
+    {
+        public string Key { get; init; } = "";
+        public string ModuleName { get; init; } = "";
+        public string Title { get; init; } = "";
+        public string LastSeverity { get; set; } = "";
+        public int IntroducedCount { get; set; }
+        public int Recurrences { get; set; }
+        public List<TimeSpan> Resolutions { get; } = [];
+        public List<TimeSpan> RecurrenceGaps { get; } = [];
+        public DateTimeOffset? LastAppeared { get; set; }
+        public DateTimeOffset? LastResolved { get; set; }
+    }
+
+    private static Dictionary<string, FindingLifecycle> TrackLifecycles(List<AuditRunRecord> sorted)
+    {
+        var lifecycles = new Dictionary<string, FindingLifecycle>(StringComparer.OrdinalIgnoreCase);
+        HashSet<string>? previousKeys = null;
+
+        foreach (var run in sorted)
+        {
+            var currentKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var finding in run.Findings)
+            {
+                if (finding.Severity.Equals("Pass", StringComparison.OrdinalIgnoreCase)) continue;
+
+                var key = $"{finding.ModuleName}||{finding.Title}";
+                currentKeys.Add(key);
+
+                if (!lifecycles.TryGetValue(key, out var lc))
+                {
+                    lc = new FindingLifecycle { Key = key, ModuleName = finding.ModuleName, Title = finding.Title };
+                    lifecycles[key] = lc;
+                }
+
+                lc.LastSeverity = finding.Severity;
+                bool wasPresent = previousKeys?.Contains(key) ?? false;
+
+                if (!wasPresent)
+                {
+                    lc.IntroducedCount++;
+                    if (lc.LastResolved.HasValue)
+                    {
+                        lc.Recurrences++;
+                        lc.RecurrenceGaps.Add(run.Timestamp - lc.LastResolved.Value);
+                        lc.LastResolved = null;
+                    }
+                }
+
+                lc.LastAppeared = run.Timestamp;
+            }
+
+            if (previousKeys != null)
+            {
+                foreach (var prevKey in previousKeys)
+                {
+                    if (!currentKeys.Contains(prevKey) && lifecycles.TryGetValue(prevKey, out var lc))
+                    {
+                        if (lc.LastAppeared.HasValue)
+                            lc.Resolutions.Add(run.Timestamp - lc.LastAppeared.Value);
+                        lc.LastResolved = run.Timestamp;
+                    }
+                }
+            }
+
+            previousKeys = currentKeys;
+        }
+
+        return lifecycles;
+    }
+
+    // ── Severity trend ───────────────────────────────────────────────
+
+    private static List<SeverityTrendPoint> ComputeSeverityTrend(List<AuditRunRecord> sorted, int windowCount)
+    {
+        if (sorted.Count <= 1 || windowCount <= 0) return [];
+
+        var totalTicks = (sorted[^1].Timestamp - sorted[0].Timestamp).Ticks;
+        if (totalTicks <= 0) return [];
+
+        var windowSize = TimeSpan.FromTicks(totalTicks / windowCount);
+        if (windowSize.Ticks <= 0) return [];
+
+        var trend = new List<SeverityTrendPoint>();
+        var first = sorted[0].Timestamp;
+
+        for (int i = 0; i < windowCount; i++)
+        {
+            var wStart = first + TimeSpan.FromTicks(windowSize.Ticks * i);
+            var wEnd = i == windowCount - 1
+                ? sorted[^1].Timestamp.AddSeconds(1)
+                : first + TimeSpan.FromTicks(windowSize.Ticks * (i + 1));
+
+            var windowRuns = sorted.Where(r => r.Timestamp >= wStart && r.Timestamp < wEnd).ToList();
+            if (windowRuns.Count == 0) continue;
+
+            var last = windowRuns[^1];
+            var findings = last.Findings
+                .Where(f => !f.Severity.Equals("Pass", StringComparison.OrdinalIgnoreCase)).ToList();
+
+            trend.Add(new SeverityTrendPoint(wStart, wEnd, windowRuns.Count,
+                new SeverityBreakdown
+                {
+                    Critical = findings.Count(f => f.Severity.Equals("Critical", StringComparison.OrdinalIgnoreCase)),
+                    Warning = findings.Count(f => f.Severity.Equals("Warning", StringComparison.OrdinalIgnoreCase)),
+                    Info = findings.Count(f => f.Severity.Equals("Info", StringComparison.OrdinalIgnoreCase))
+                },
+                last.OverallScore));
+        }
+
+        return trend;
+    }
+
+    // ── Module health ────────────────────────────────────────────────
+
+    private static List<ModuleHealth> ComputeModuleHealth(
+        List<AuditRunRecord> sorted, Dictionary<string, FindingLifecycle> lifecycles)
+    {
+        var moduleNames = sorted.SelectMany(r => r.ModuleScores).Select(m => m.ModuleName)
+            .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+        var results = new List<ModuleHealth>();
+
+        foreach (var mod in moduleNames)
+        {
+            var modLcs = lifecycles.Values
+                .Where(l => l.ModuleName.Equals(mod, StringComparison.OrdinalIgnoreCase)).ToList();
+
+            var perRun = sorted
+                .Select(r => r.Findings.Count(f =>
+                    f.ModuleName.Equals(mod, StringComparison.OrdinalIgnoreCase)
+                    && !f.Severity.Equals("Pass", StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+
+            int current = perRun.Count > 0 ? perRun[^1] : 0;
+            int peak = perRun.Count > 0 ? perRun.Max() : 0;
+            double avg = perRun.Count > 0 ? perRun.Average() : 0;
+            int introduced = modLcs.Sum(l => l.IntroducedCount);
+            int resolved = modLcs.Sum(l => l.Resolutions.Count);
+            int recurrent = modLcs.Count(l => l.Recurrences > 0);
+
+            double mttr = modLcs.SelectMany(l => l.Resolutions).Any()
+                ? modLcs.SelectMany(l => l.Resolutions).Average(r => r.TotalHours) : 0;
+            double recRate = resolved > 0 ? (double)recurrent / resolved * 100 : 0;
+
+            string cat = sorted.SelectMany(r => r.ModuleScores)
+                .Where(m => m.ModuleName.Equals(mod, StringComparison.OrdinalIgnoreCase))
+                .Select(m => m.Category).LastOrDefault() ?? "";
+
+            double score = 100;
+            score -= current * 5;
+            score -= Math.Min(15, recRate * 0.3);
+            if (mttr > 48) score -= Math.Min(20, (mttr - 48) / 8);
+            if (introduced > 0 && resolved < introduced)
+                score -= Math.Min(15, (introduced - resolved) * 3);
+            score = Math.Clamp(score, 0, 100);
+
+            results.Add(new ModuleHealth(mod, cat, current, peak, Math.Round(avg, 1),
+                introduced, resolved, Math.Round(mttr, 2), Math.Round(recRate, 1),
+                ScoreToGrade(score)));
+        }
+
+        return results.OrderByDescending(m => m.CurrentFindings).ToList();
+    }
+
+    // ── Scoring ──────────────────────────────────────────────────────
+
+    private static double ComputeHealthScore(
+        double mttrHours, double recurrenceRate, SeverityBreakdown severity, double resolutionEfficiency)
+    {
+        double score = 100;
+        if (mttrHours > 72) score -= Math.Min(25, (mttrHours - 72) / 10);
+        score -= Math.Min(20, recurrenceRate * 0.5);
+        score -= severity.Critical * 8;
+        score -= severity.Warning * 2;
+        score -= severity.Info * 0.5;
+        if (resolutionEfficiency >= 1.0) score += 5;
+        else if (resolutionEfficiency < 0.5) score -= 10;
+        return Math.Clamp(score, 0, 100);
+    }
+
+    private static string ScoreToGrade(double score) => score switch
+    {
+        >= 90 => "A",
+        >= 80 => "B",
+        >= 70 => "C",
+        >= 60 => "D",
+        _ => "F"
+    };
+
+    // ── Summary ──────────────────────────────────────────────────────
+
+    private static string BuildSummary(
+        int runs, TimeSpan period, double mttrHours, double mttdHours,
+        double findingVelocity, double resolutionVelocity, double resolutionEfficiency,
+        double recurrenceRate, int currentlyOpen, SeverityBreakdown severity,
+        string grade, double healthScore)
+    {
+        var lines = new List<string>
+        {
+            $"Security Metrics Report — Grade: {grade} ({healthScore:F1}/100)",
+            $"  Analyzed {runs} runs over {period.TotalDays:F0} days",
+            "",
+            "Key Performance Indicators:",
+            $"  MTTR (Mean Time to Resolve):   {FormatDuration(mttrHours)}",
+            $"  MTTD (Mean Time to Detect):    {FormatDuration(mttdHours)}",
+            $"  Finding Velocity:              {findingVelocity:F2}/day introduced, {resolutionVelocity:F2}/day resolved",
+            $"  Resolution Efficiency:         {resolutionEfficiency:P1}",
+            $"  Recurrence Rate:               {recurrenceRate:F1}%",
+            "",
+            $"Current State: {currentlyOpen} open findings",
+            $"  Critical: {severity.Critical}  Warning: {severity.Warning}  Info: {severity.Info}"
+        };
+
+        if (resolutionEfficiency < 0.8)
+            lines.Add("\n⚠ Resolution efficiency below 80% — findings accumulating faster than resolved.");
+        if (recurrenceRate > 20)
+            lines.Add("⚠ High recurrence rate — consider root-cause analysis on recurring findings.");
+        if (severity.Critical > 0)
+            lines.Add($"⚠ {severity.Critical} critical finding(s) require immediate attention.");
+
+        return string.Join("\n", lines);
+    }
+
+    private static string FormatDuration(double hours) => hours switch
+    {
+        < 1 => $"{hours * 60:F0} minutes",
+        < 24 => $"{hours:F1} hours",
+        _ => $"{hours / 24:F1} days"
+    };
+}

--- a/tests/WinSentinel.Tests/Services/SecurityMetricsAggregatorTests.cs
+++ b/tests/WinSentinel.Tests/Services/SecurityMetricsAggregatorTests.cs
@@ -1,0 +1,500 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests.Services;
+
+public class SecurityMetricsAggregatorTests
+{
+    private readonly SecurityMetricsAggregator _aggregator = new();
+
+    private static AuditRunRecord MakeRun(
+        long id, DateTimeOffset timestamp, int score,
+        params (string module, string category, string title, string severity)[] findings)
+    {
+        var run = new AuditRunRecord
+        {
+            Id = id, Timestamp = timestamp, OverallScore = score,
+            Grade = score >= 90 ? "A" : score >= 80 ? "B" : score >= 70 ? "C" : "D",
+            TotalFindings = findings.Length,
+            CriticalCount = findings.Count(f => f.severity == "Critical"),
+            WarningCount = findings.Count(f => f.severity == "Warning"),
+            InfoCount = findings.Count(f => f.severity == "Info"),
+            PassCount = 0, IsScheduled = false
+        };
+
+        foreach (var group in findings.GroupBy(f => f.module))
+        {
+            run.ModuleScores.Add(new ModuleScoreRecord
+            {
+                ModuleName = group.Key, Category = group.First().category,
+                Score = score, FindingCount = group.Count(),
+                CriticalCount = group.Count(f => f.severity == "Critical"),
+                WarningCount = group.Count(f => f.severity == "Warning")
+            });
+        }
+
+        foreach (var (module, _, title, severity) in findings)
+            run.Findings.Add(new FindingRecord
+            {
+                ModuleName = module, Title = title,
+                Severity = severity, Description = $"Test: {title}"
+            });
+
+        return run;
+    }
+
+    private static DateTimeOffset T(int dayOffset) =>
+        new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero).AddDays(dayOffset);
+
+    [Fact]
+    public void Analyze_NullRuns_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => _aggregator.Analyze(null!));
+    }
+
+    [Fact]
+    public void Analyze_EmptyRuns_EmptyReport()
+    {
+        var r = _aggregator.Analyze([]);
+        Assert.Equal(0, r.RunsAnalyzed);
+        Assert.Equal("N/A", r.HealthGrade);
+        Assert.Contains("No audit runs", r.Summary);
+    }
+
+    [Fact]
+    public void Analyze_SingleRun_BasicMetrics()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 85,
+                ("Firewall", "Network", "Open port 3389", "Warning"),
+                ("Updates", "System", "Missing KB12345", "Critical"))
+        });
+
+        Assert.Equal(1, r.RunsAnalyzed);
+        Assert.Equal(2, r.CurrentlyOpen);
+        Assert.Equal(2, r.TotalUnique);
+        Assert.Equal(0, r.TotalResolved);
+        Assert.Equal(1, r.CurrentSeverity.Critical);
+        Assert.Equal(1, r.CurrentSeverity.Warning);
+    }
+
+    [Fact]
+    public void Analyze_FindingResolved_CalculatesMttr()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(2), 90)
+        });
+
+        Assert.Equal(1, r.TotalResolved);
+        Assert.Equal(48, r.MttrHours);
+    }
+
+    [Fact]
+    public void Analyze_MultipleFindingsResolved_AveragesMttr()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 60, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Critical")),
+            MakeRun(2, T(1), 70, ("B", "Cat", "F2", "Critical")),
+            MakeRun(3, T(3), 95)
+        });
+
+        Assert.Equal(2, r.TotalResolved);
+        Assert.True(r.MttrHours > 0);
+    }
+
+    [Fact]
+    public void Analyze_Mttd_AverageGaps()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 85), MakeRun(2, T(1), 85), MakeRun(3, T(3), 85)
+        });
+
+        Assert.Equal(36, r.MttdHours);
+    }
+
+    [Fact]
+    public void Analyze_FindingVelocity()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(5), 60, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Critical")),
+            MakeRun(3, T(10), 50, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Critical"), ("C", "Cat", "F3", "Critical"))
+        });
+
+        Assert.Equal(0.3, r.FindingVelocityPerDay);
+    }
+
+    [Fact]
+    public void Analyze_RecurringFinding_Tracked()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(2), 90),
+            MakeRun(3, T(4), 70, ("A", "Cat", "F1", "Warning"))
+        });
+
+        Assert.Equal(1, r.TotalRecurrent);
+        Assert.True(r.RecurrenceRatePercent > 0);
+        Assert.Single(r.TopRecurring);
+        Assert.Equal("F1", r.TopRecurring[0].Title);
+    }
+
+    [Fact]
+    public void Analyze_NoRecurrence_ZeroRate()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(2), 90)
+        });
+
+        Assert.Equal(0, r.TotalRecurrent);
+        Assert.Empty(r.TopRecurring);
+    }
+
+    [Fact]
+    public void Analyze_AllResolved_EfficiencyOne()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(2), 95)
+        });
+
+        Assert.Equal(1.0, r.ResolutionEfficiency);
+    }
+
+    [Fact]
+    public void Analyze_NoneResolved_EfficiencyZero()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(2), 60, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Critical"))
+        });
+
+        Assert.Equal(0, r.ResolutionEfficiency);
+    }
+
+    [Fact]
+    public void Analyze_MixedSeverity_CorrectBreakdown()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 50,
+                ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Critical"),
+                ("C", "Cat", "F3", "Info"), ("D", "Cat", "F4", "Critical"))
+        });
+
+        Assert.Equal(2, r.CurrentSeverity.Critical);
+        Assert.Equal(1, r.CurrentSeverity.Warning);
+        Assert.Equal(1, r.CurrentSeverity.Info);
+        Assert.Equal(4, r.CurrentSeverity.Total);
+    }
+
+    [Fact]
+    public void Analyze_PassFindings_Excluded()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 85, ("A", "Cat", "Pass check", "Pass"), ("B", "Cat", "F1", "Warning"))
+        });
+
+        Assert.Equal(1, r.TotalUnique);
+        Assert.Equal(1, r.CurrentlyOpen);
+    }
+
+    [Fact]
+    public void Analyze_SeverityTrend_Windows()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(10), 60, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Critical")),
+            MakeRun(3, T(20), 80, ("B", "Cat", "F2", "Critical")),
+            MakeRun(4, T(30), 95)
+        }, windowCount: 3);
+
+        Assert.True(r.SeverityTrend.Count > 0);
+        Assert.True(r.SeverityTrend.Count <= 3);
+    }
+
+    [Fact]
+    public void Analyze_SingleRun_NoSeverityTrend()
+    {
+        var r = _aggregator.Analyze(new[] { MakeRun(1, T(0), 85, ("A", "Cat", "F1", "Warning")) });
+        Assert.Empty(r.SeverityTrend);
+    }
+
+    [Fact]
+    public void Analyze_ZeroWindowCount_EmptyTrend()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(5), 90)
+        }, windowCount: 0);
+
+        Assert.Empty(r.SeverityTrend);
+    }
+
+    [Fact]
+    public void Analyze_ModuleHealth_Computed()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 60,
+                ("Firewall", "Network", "Open port", "Warning"),
+                ("Firewall", "Network", "No outbound", "Info"),
+                ("Updates", "System", "Missing KB", "Critical")),
+            MakeRun(2, T(3), 70,
+                ("Firewall", "Network", "Open port", "Warning"),
+                ("Updates", "System", "Missing KB", "Critical")),
+            MakeRun(3, T(6), 85, ("Firewall", "Network", "Open port", "Warning"))
+        });
+
+        Assert.Equal(2, r.Modules.Count);
+        var fw = r.Modules.First(m => m.ModuleName == "Firewall");
+        Assert.Equal(1, fw.CurrentFindings);
+        Assert.Equal(2, fw.PeakFindings);
+        var upd = r.Modules.First(m => m.ModuleName == "Updates");
+        Assert.Equal(0, upd.CurrentFindings);
+        Assert.Equal(1, upd.TotalResolved);
+    }
+
+    [Fact]
+    public void Analyze_ModuleCategory_Populated()
+    {
+        var r = _aggregator.Analyze(new[] { MakeRun(1, T(0), 70, ("Firewall", "Network", "F1", "Warning")) });
+        Assert.Equal("Network", r.Modules[0].Category);
+    }
+
+    [Fact]
+    public void Analyze_CleanState_GradeA()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 95, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(1), 100)
+        });
+
+        Assert.Equal("A", r.HealthGrade);
+        Assert.True(r.HealthScore >= 90);
+    }
+
+    [Fact]
+    public void Analyze_ManyCriticals_LowGrade()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 30,
+                ("A", "Cat", "C1", "Critical"), ("B", "Cat", "C2", "Critical"),
+                ("C", "Cat", "C3", "Critical"), ("D", "Cat", "C4", "Critical"),
+                ("E", "Cat", "C5", "Critical"))
+        });
+
+        Assert.True(r.HealthScore < 70);
+    }
+
+    [Fact]
+    public void Analyze_Summary_ContainsKPIs()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(5), 90)
+        });
+
+        Assert.Contains("MTTR", r.Summary);
+        Assert.Contains("MTTD", r.Summary);
+        Assert.Contains("Velocity", r.Summary);
+        Assert.Contains("Recurrence", r.Summary);
+    }
+
+    [Fact]
+    public void Analyze_LowEfficiency_Warning()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(5), 60,
+                ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Warning"),
+                ("C", "Cat", "F3", "Warning"), ("D", "Cat", "F4", "Critical"))
+        });
+
+        Assert.Contains("below 80%", r.Summary);
+    }
+
+    [Fact]
+    public void Analyze_CriticalFinding_WarningInSummary()
+    {
+        var r = _aggregator.Analyze(new[] { MakeRun(1, T(0), 50, ("A", "Cat", "F1", "Critical")) });
+        Assert.Contains("critical", r.Summary);
+    }
+
+    [Fact]
+    public void Analyze_TopRecurringCount_Limits()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 50, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Warning"), ("C", "Cat", "F3", "Warning")),
+            MakeRun(2, T(1), 90),
+            MakeRun(3, T(2), 50, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Warning"), ("C", "Cat", "F3", "Warning"))
+        }, topRecurringCount: 1);
+
+        Assert.True(r.TopRecurring.Count <= 1);
+    }
+
+    [Fact]
+    public void Analyze_UnorderedRuns_StillCorrect()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(3, T(4), 90),
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(2), 85, ("A", "Cat", "F1", "Warning"))
+        });
+
+        Assert.Equal(3, r.RunsAnalyzed);
+        Assert.Equal(0, r.CurrentlyOpen);
+        Assert.Equal(1, r.TotalResolved);
+    }
+
+    [Fact]
+    public void Analyze_CorrectPeriod()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 85), MakeRun(2, T(10), 85), MakeRun(3, T(30), 85)
+        });
+
+        Assert.Equal(30, r.AnalysisPeriod.TotalDays);
+        Assert.Equal(T(0), r.FirstRun);
+        Assert.Equal(T(30), r.LastRun);
+    }
+
+    [Fact]
+    public void Analyze_ResolutionVelocity()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 60, ("A", "Cat", "F1", "Warning"), ("B", "Cat", "F2", "Critical")),
+            MakeRun(2, T(10), 90)
+        });
+
+        Assert.Equal(0.2, r.ResolutionVelocityPerDay);
+    }
+
+    [Fact]
+    public void Analyze_CaseInsensitiveMatching()
+    {
+        var run1 = MakeRun(1, T(0), 70);
+        run1.Findings.Add(new FindingRecord { ModuleName = "Firewall", Title = "Open Port", Severity = "Warning", Description = "t" });
+        var run2 = MakeRun(2, T(2), 70);
+        run2.Findings.Add(new FindingRecord { ModuleName = "firewall", Title = "open port", Severity = "Warning", Description = "t" });
+
+        var r = _aggregator.Analyze(new[] { run1, run2 });
+        Assert.Equal(1, r.TotalUnique);
+    }
+
+    [Fact]
+    public void Analyze_SameDayRuns_NoDivisionByZero()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(0).AddHours(1), 90)
+        });
+
+        Assert.False(double.IsNaN(r.FindingVelocityPerDay));
+        Assert.True(r.FindingVelocityPerDay >= 0);
+    }
+
+    [Fact]
+    public void Analyze_MultipleRecurrences_Counted()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(1), 90),
+            MakeRun(3, T(2), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(4, T(3), 90),
+            MakeRun(5, T(4), 70, ("A", "Cat", "F1", "Warning"))
+        });
+
+        var recurring = r.TopRecurring.First(x => x.Title == "F1");
+        Assert.Equal(2, recurring.Recurrences);
+        Assert.Equal(3, recurring.Occurrences);
+    }
+
+    [Fact]
+    public void Analyze_HighRecurrence_WarningInSummary()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(1), 90),
+            MakeRun(3, T(2), 70, ("A", "Cat", "F1", "Warning"))
+        });
+
+        Assert.True(r.RecurrenceRatePercent > 20);
+        Assert.Contains("recurrence", r.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Analyze_NoFindings_HighHealthScore()
+    {
+        var r = _aggregator.Analyze(new[] { MakeRun(1, T(0), 100), MakeRun(2, T(5), 100) });
+
+        Assert.Equal(0, r.CurrentlyOpen);
+        Assert.True(r.HealthScore >= 90);
+        Assert.Equal("A", r.HealthGrade);
+    }
+
+    [Fact]
+    public void Analyze_ModuleHealth_OrderedByCurrentFindings()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 50,
+                ("A", "Cat", "F1", "Warning"),
+                ("B", "Cat", "F2", "Warning"), ("B", "Cat", "F3", "Warning"), ("B", "Cat", "F4", "Critical"))
+        });
+
+        Assert.Equal("B", r.Modules[0].ModuleName);
+        Assert.Equal("A", r.Modules[1].ModuleName);
+    }
+
+    [Fact]
+    public void Analyze_SeverityTrendPoint_HasOverallScore()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(10), 85, ("A", "Cat", "F1", "Warning"))
+        }, windowCount: 2);
+
+        Assert.True(r.SeverityTrend.Count > 0);
+        Assert.True(r.SeverityTrend.All(p => p.OverallScore > 0));
+    }
+
+    [Fact]
+    public void Analyze_RecurringFinding_AvgDaysBeforeRecurrence()
+    {
+        var r = _aggregator.Analyze(new[]
+        {
+            MakeRun(1, T(0), 70, ("A", "Cat", "F1", "Warning")),
+            MakeRun(2, T(2), 90),
+            MakeRun(3, T(6), 70, ("A", "Cat", "F1", "Warning"))
+        });
+
+        Assert.True(r.TopRecurring.First().AvgDaysBeforeRecurrence > 0);
+    }
+}


### PR DESCRIPTION
## SecurityMetricsAggregator

Adds a comprehensive security metrics aggregation service that computes operational KPIs from audit run history.

### Key Metrics
- **MTTR** (Mean Time to Resolve) — average time findings stay open before resolution
- **MTTD** (Mean Time to Detect) — average scan interval (proxy for detection latency)
- **Finding Velocity** — rate of new findings introduced per day
- **Resolution Velocity** — rate of findings resolved per day
- **Resolution Efficiency** — ratio of resolved to introduced findings
- **Recurrence Rate** — percentage of resolved findings that reappear
- **Severity Breakdown** — critical/warning/info counts with trends over time windows
- **Module Health** — per-module scoring with individual grades (A-F)
- **Health Score** — composite 0-100 score with letter grade
- **Top Recurring Findings** — findings that keep coming back, with avg recurrence gap

### CLI Integration
- \--metrics\ command with colorized dashboard output
- \--metrics-days N\ to control analysis window (default 90)
- \--metrics-windows N\ to control trend window count (default 6)
- \--metrics-top N\ to limit top recurring findings (default 10)
- \--json\ flag for machine-readable output

### Files Changed
- \src/WinSentinel.Core/Services/SecurityMetricsAggregator.cs\ — core service (lifecycle tracking, trend computation, health scoring)
- \src/WinSentinel.Cli/ConsoleFormatter.Metrics.cs\ — colorized CLI dashboard
- \src/WinSentinel.Cli/CliParser.cs\ — CLI argument parsing for --metrics
- \src/WinSentinel.Cli/Program.cs\ — command routing
- \	ests/WinSentinel.Tests/Services/SecurityMetricsAggregatorTests.cs\ — 35 tests covering all KPIs, edge cases, case insensitivity, division-by-zero safety