### PR TITLE
feat: Audit Notes — persistent finding annotations

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -72,6 +72,14 @@ public class CliOptions
     public int RootCauseTop { get; set; } = 10;
     public string? RootCauseSeverityFilter { get; set; }
     public int ScheduleOptimizeDays { get; set; } = 90;
+    public NoteAction NoteAction { get; set; } = NoteAction.None;
+    public string? NoteText { get; set; }
+    public string? NoteFindingPattern { get; set; }
+    public string? NoteId { get; set; }
+    public string? NoteCategory { get; set; }
+    public string? NoteModule { get; set; }
+    public string? NoteQuery { get; set; }
+    public bool NotePinned { get; set; }
 }
 
 public enum CliCommand
@@ -97,6 +105,7 @@ public enum CliCommand
     RootCause,
     Threats,
     ScheduleOptimize,
+    Notes,
     Help,
     Version
 }
@@ -166,6 +175,11 @@ public enum RootCauseAction
     Top,
     Causes,
     Ungrouped
+}
+
+public enum NoteAction
+{
+    None, Add, List, Search, Update, Remove, Clear, Stats
 }
 
 /// <summary>
@@ -426,6 +440,58 @@ public static class CliParser
 
                 case "--schedule-optimize":
                     options.Command = CliCommand.ScheduleOptimize;
+                    break;
+
+                case "--notes":
+                    options.Command = CliCommand.Notes;
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith("-"))
+                    {
+                        var noteAction = args[++i].ToLowerInvariant();
+                        options.NoteAction = noteAction switch
+                        {
+                            "add" => NoteAction.Add, "list" => NoteAction.List,
+                            "search" => NoteAction.Search, "update" => NoteAction.Update,
+                            "remove" or "rm" => NoteAction.Remove, "clear" => NoteAction.Clear,
+                            "stats" => NoteAction.Stats, _ => NoteAction.None
+                        };
+                        if (options.NoteAction == NoteAction.None)
+                        { options.Error = $"Unknown notes action: {noteAction}."; return options; }
+                        if (options.NoteAction == NoteAction.Add)
+                        {
+                            if (i + 1 < args.Length && !args[i + 1].StartsWith("-")) options.NoteFindingPattern = args[++i];
+                            else { options.Error = "Missing finding pattern for 'notes add'."; return options; }
+                        }
+                        if (options.NoteAction is NoteAction.Update or NoteAction.Remove)
+                        {
+                            if (i + 1 < args.Length && !args[i + 1].StartsWith("-")) options.NoteId = args[++i];
+                            else { options.Error = $"Missing note ID for 'notes {noteAction}'."; return options; }
+                        }
+                        if (options.NoteAction == NoteAction.Search)
+                        {
+                            if (i + 1 < args.Length && !args[i + 1].StartsWith("-")) options.NoteQuery = args[++i];
+                            else { options.Error = "Missing query for 'notes search'."; return options; }
+                        }
+                    }
+                    else { options.NoteAction = NoteAction.List; }
+                    break;
+
+                case "--note-text":
+                    if (i + 1 < args.Length) options.NoteText = args[++i];
+                    else { options.Error = "Missing value for --note-text."; return options; }
+                    break;
+
+                case "--note-category":
+                    if (i + 1 < args.Length) options.NoteCategory = args[++i];
+                    else { options.Error = "Missing value for --note-category."; return options; }
+                    break;
+
+                case "--note-module":
+                    if (i + 1 < args.Length) options.NoteModule = args[++i];
+                    else { options.Error = "Missing value for --note-module."; return options; }
+                    break;
+
+                case "--note-pin":
+                    options.NotePinned = true;
                     break;
 
                 case "export" when options.Command == CliCommand.Policy:

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -40,6 +40,7 @@ return options.Command switch
     CliCommand.RootCause => await HandleRootCause(options),
     CliCommand.Threats => await HandleThreats(options),
     CliCommand.ScheduleOptimize => HandleScheduleOptimize(options),
+    CliCommand.Notes => HandleNotes(options),
     _ => HandleHelp()
 };
 
@@ -2412,4 +2413,163 @@ static int HandleScheduleOptimize(CliOptions options)
 
     ConsoleFormatter.PrintScheduleOptimizeResult(result);
     return 0;
+}
+
+// ── Audit Notes ──────────────────────────────────────────────────────
+
+static int HandleNotes(CliOptions options)
+{
+    var service = new AuditNoteService();
+    return options.NoteAction switch
+    {
+        NoteAction.Add => HandleNoteAdd(service, options),
+        NoteAction.List => HandleNoteList(service, options),
+        NoteAction.Search => HandleNoteSearch(service, options),
+        NoteAction.Update => HandleNoteUpdate(service, options),
+        NoteAction.Remove => HandleNoteRemove(service, options),
+        NoteAction.Clear => HandleNoteClear(service, options),
+        NoteAction.Stats => HandleNoteStats(service, options),
+        _ => HandleNoteList(service, options)
+    };
+}
+
+static int HandleNoteAdd(AuditNoteService service, CliOptions options)
+{
+    if (string.IsNullOrWhiteSpace(options.NoteText))
+    { ConsoleFormatter.PrintError("Missing note text. Use --note-text <text>"); return 3; }
+
+    var category = NoteCategory.Comment;
+    if (!string.IsNullOrEmpty(options.NoteCategory) && !Enum.TryParse(options.NoteCategory, true, out category))
+    { ConsoleFormatter.PrintError($"Unknown category: {options.NoteCategory}."); return 3; }
+
+    try
+    {
+        var note = service.Add(options.NoteFindingPattern!, options.NoteText, category, options.NoteModule, pinned: options.NotePinned);
+        if (options.Json)
+        {
+            var jo = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+            WriteOutput(JsonSerializer.Serialize(new { action = "added", id = note.Id, findingPattern = note.FindingPattern, text = note.Text, category = note.Category.ToString(), module = note.Module, author = note.Author, pinned = note.Pinned, createdAt = note.CreatedAt }, jo), options.OutputFile);
+        }
+        else if (!options.Quiet)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"\n  \u2713 Note added (ID: {note.Id})");
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"    Pattern: \"{note.FindingPattern}\" | Category: {note.Category} | Pinned: {(note.Pinned ? "yes" : "no")}");
+            Console.ResetColor(); Console.WriteLine();
+        }
+        return 0;
+    }
+    catch (ArgumentException ex) { ConsoleFormatter.PrintError(ex.Message); return 3; }
+}
+
+static int HandleNoteList(AuditNoteService service, CliOptions options)
+{
+    var notes = service.GetAll();
+    if (notes.Count == 0)
+    {
+        if (options.Json) WriteOutput("[]", options.OutputFile);
+        else if (!options.Quiet) { Console.ForegroundColor = ConsoleColor.Yellow; Console.WriteLine("  No audit notes found."); Console.ResetColor(); }
+        return 0;
+    }
+    if (options.Json)
+    {
+        var jo = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+        WriteOutput(JsonSerializer.Serialize(notes, jo), options.OutputFile);
+    }
+    else PrintNotesList(notes, options.Quiet);
+    return 0;
+}
+
+static int HandleNoteSearch(AuditNoteService service, CliOptions options)
+{
+    var result = service.Search(options.NoteQuery!);
+    if (options.Json)
+    {
+        var jo = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+        WriteOutput(JsonSerializer.Serialize(result, jo), options.OutputFile);
+        return 0;
+    }
+    if (result.Notes.Count == 0) { Console.ForegroundColor = ConsoleColor.Yellow; Console.WriteLine($"  No notes matching \"{result.Query}\"."); Console.ResetColor(); return 0; }
+    Console.ForegroundColor = ConsoleColor.Cyan; Console.WriteLine($"\n  Search: \"{result.Query}\" \u2014 {result.Notes.Count} match(es) of {result.TotalNotes} total\n"); Console.ResetColor();
+    PrintNotesList(result.Notes, options.Quiet);
+    return 0;
+}
+
+static int HandleNoteUpdate(AuditNoteService service, CliOptions options)
+{
+    NoteCategory? cat = null;
+    if (!string.IsNullOrEmpty(options.NoteCategory))
+    { if (!Enum.TryParse<NoteCategory>(options.NoteCategory, true, out var p)) { ConsoleFormatter.PrintError($"Unknown category: {options.NoteCategory}."); return 3; } cat = p; }
+    var note = service.Update(options.NoteId!, options.NoteText, cat, options.NotePinned ? true : null);
+    if (note == null) { ConsoleFormatter.PrintError($"Note '{options.NoteId}' not found."); return 3; }
+    if (options.Json) { var jo = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } }; WriteOutput(JsonSerializer.Serialize(note, jo), options.OutputFile); }
+    else if (!options.Quiet) { Console.ForegroundColor = ConsoleColor.Green; Console.WriteLine($"  \u2713 Note '{note.Id}' updated."); Console.ResetColor(); }
+    return 0;
+}
+
+static int HandleNoteRemove(AuditNoteService service, CliOptions options)
+{
+    if (service.Remove(options.NoteId!))
+    {
+        if (options.Json) WriteOutput($"{{\"action\": \"removed\", \"id\": \"{options.NoteId}\"}}", options.OutputFile);
+        else if (!options.Quiet) { Console.ForegroundColor = ConsoleColor.Green; Console.WriteLine($"  \u2713 Note '{options.NoteId}' removed."); Console.ResetColor(); }
+        return 0;
+    }
+    ConsoleFormatter.PrintError($"Note '{options.NoteId}' not found."); return 3;
+}
+
+static int HandleNoteClear(AuditNoteService service, CliOptions options)
+{
+    var count = service.Clear();
+    if (options.Json) WriteOutput($"{{\"action\": \"cleared\", \"removed\": {count}}}", options.OutputFile);
+    else if (!options.Quiet) { Console.ForegroundColor = ConsoleColor.Green; Console.WriteLine($"  \u2713 Cleared {count} note(s)."); Console.ResetColor(); }
+    return 0;
+}
+
+static int HandleNoteStats(AuditNoteService service, CliOptions options)
+{
+    var stats = service.GetStats();
+    if (options.Json) { var jo = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } }; WriteOutput(JsonSerializer.Serialize(stats, jo), options.OutputFile); return 0; }
+    Console.ForegroundColor = ConsoleColor.Cyan;
+    Console.WriteLine("\n  \u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557");
+    Console.WriteLine("  \u2551         Audit Notes Statistics        \u2551");
+    Console.WriteLine("  \u255a\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255d");
+    Console.ResetColor();
+    Console.Write("\n  Total: "); Console.ForegroundColor = ConsoleColor.White; Console.WriteLine(stats.TotalNotes); Console.ResetColor();
+    Console.Write("  Pinned: "); Console.ForegroundColor = stats.PinnedNotes > 0 ? ConsoleColor.Yellow : ConsoleColor.DarkGray; Console.WriteLine(stats.PinnedNotes); Console.ResetColor();
+    if (stats.ByCategory.Count > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.White; Console.WriteLine("\n  By Category:"); Console.ResetColor();
+        foreach (var (cat, count) in stats.ByCategory.OrderByDescending(kv => kv.Value))
+        { Console.Write($"    {cat,-16}"); Console.ForegroundColor = ConsoleColor.Cyan; Console.WriteLine(count); Console.ResetColor(); }
+    }
+    Console.WriteLine();
+    return 0;
+}
+
+static void PrintNotesList(List<AuditNote> notes, bool quiet)
+{
+    if (quiet) { foreach (var n in notes) Console.WriteLine($"{n.Id}\t{n.FindingPattern}\t{n.Category}\t{n.Text}"); return; }
+    Console.WriteLine();
+    Console.ForegroundColor = ConsoleColor.White;
+    Console.WriteLine($"  {"ID",-10} {"Pattern",-30} {"Category",-14} {"Pin",3}  Note");
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.WriteLine($"  {"----------",-10} {"------------------------------",-30} {"--------------",-14} {"---",3}  ----------------------------");
+    Console.ResetColor();
+    foreach (var n in notes)
+    {
+        Console.ForegroundColor = ConsoleColor.DarkCyan; Console.Write($"  {n.Id,-10} ");
+        Console.ForegroundColor = ConsoleColor.White;
+        var p = n.FindingPattern.Length > 28 ? n.FindingPattern[..28] + ".." : n.FindingPattern;
+        Console.Write($"{p,-30} ");
+        Console.ForegroundColor = n.Category switch { NoteCategory.Accepted => ConsoleColor.Green, NoteCategory.Deferred => ConsoleColor.Yellow, NoteCategory.InProgress => ConsoleColor.Cyan, NoteCategory.WontFix => ConsoleColor.DarkGray, NoteCategory.FalsePositive => ConsoleColor.Magenta, _ => ConsoleColor.White };
+        Console.Write($"{n.Category,-14} ");
+        Console.ForegroundColor = n.Pinned ? ConsoleColor.Yellow : ConsoleColor.DarkGray;
+        Console.Write($"{(n.Pinned ? "Y" : " "),3}  ");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine(n.Text.Length > 40 ? n.Text[..40] + "..." : n.Text);
+        Console.ResetColor();
+    }
+    Console.WriteLine();
 }

--- a/src/WinSentinel.Core/Models/AuditNoteModels.cs
+++ b/src/WinSentinel.Core/Models/AuditNoteModels.cs
@@ -1,0 +1,51 @@
+namespace WinSentinel.Core.Models;
+
+/// <summary>
+/// A user-created annotation attached to a finding by title pattern.
+/// </summary>
+public class AuditNote
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N")[..8];
+    public string FindingPattern { get; set; } = "";
+    public string Text { get; set; } = "";
+    public string? Module { get; set; }
+    public string? Author { get; set; }
+    public NoteCategory Category { get; set; } = NoteCategory.Comment;
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? UpdatedAt { get; set; }
+    public bool Pinned { get; set; }
+}
+
+public enum NoteCategory
+{
+    Comment,
+    Accepted,
+    Deferred,
+    InProgress,
+    WontFix,
+    FalsePositive
+}
+
+public class MatchedNote
+{
+    public AuditNote Note { get; set; } = null!;
+    public string FindingTitle { get; set; } = "";
+    public string? FindingModule { get; set; }
+    public string? FindingSeverity { get; set; }
+}
+
+public class NoteSearchResult
+{
+    public List<AuditNote> Notes { get; set; } = [];
+    public string Query { get; set; } = "";
+    public int TotalNotes { get; set; }
+}
+
+public class NoteStats
+{
+    public int TotalNotes { get; set; }
+    public int PinnedNotes { get; set; }
+    public Dictionary<string, int> ByCategory { get; set; } = new();
+    public DateTimeOffset? OldestNote { get; set; }
+    public DateTimeOffset? NewestNote { get; set; }
+}

--- a/src/WinSentinel.Core/Services/AuditNoteService.cs
+++ b/src/WinSentinel.Core/Services/AuditNoteService.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+public class AuditNoteService
+{
+    private readonly string _filePath;
+    private List<AuditNote>? _cache;
+
+    public AuditNoteService() : this(GetDefaultPath()) { }
+    public AuditNoteService(string filePath) { _filePath = filePath; }
+
+    public static string GetDefaultPath()
+    {
+        var local = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(local, "WinSentinel", "notes.json");
+    }
+
+    public AuditNote Add(string findingPattern, string text,
+        NoteCategory category = NoteCategory.Comment,
+        string? module = null, string? author = null, bool pinned = false)
+    {
+        if (string.IsNullOrWhiteSpace(findingPattern))
+            throw new ArgumentException("Finding pattern is required.", nameof(findingPattern));
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ArgumentException("Note text is required.", nameof(text));
+
+        var notes = Load();
+        var note = new AuditNote
+        {
+            FindingPattern = findingPattern, Text = text, Category = category,
+            Module = module, Author = author ?? Environment.UserName, Pinned = pinned
+        };
+        notes.Add(note);
+        Save(notes);
+        return note;
+    }
+
+    public List<AuditNote> GetAll() => Load();
+
+    public AuditNote? Get(string id) =>
+        Load().FirstOrDefault(n => n.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+
+    public AuditNote? Update(string id, string? newText = null, NoteCategory? newCategory = null, bool? pinned = null)
+    {
+        var notes = Load();
+        var note = notes.FirstOrDefault(n => n.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+        if (note == null) return null;
+        if (newText != null) note.Text = newText;
+        if (newCategory.HasValue) note.Category = newCategory.Value;
+        if (pinned.HasValue) note.Pinned = pinned.Value;
+        note.UpdatedAt = DateTimeOffset.UtcNow;
+        Save(notes);
+        return note;
+    }
+
+    public bool Remove(string id)
+    {
+        var notes = Load();
+        var removed = notes.RemoveAll(n => n.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+        if (removed > 0) Save(notes);
+        return removed > 0;
+    }
+
+    public int Clear()
+    {
+        var notes = Load();
+        var count = notes.Count;
+        if (count > 0) Save([]);
+        return count;
+    }
+
+    public NoteSearchResult Search(string query)
+    {
+        var all = Load();
+        var matched = all.Where(n =>
+            n.Text.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+            n.FindingPattern.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+            (n.Module != null && n.Module.Contains(query, StringComparison.OrdinalIgnoreCase))
+        ).ToList();
+        return new NoteSearchResult { Notes = matched, Query = query, TotalNotes = all.Count };
+    }
+
+    public List<MatchedNote> Match(List<(string Title, string Module, string Severity)> findings)
+    {
+        var notes = Load();
+        if (notes.Count == 0) return [];
+        var result = new List<MatchedNote>();
+        foreach (var finding in findings)
+        {
+            foreach (var note in notes)
+            {
+                if (!finding.Title.Contains(note.FindingPattern, StringComparison.OrdinalIgnoreCase)) continue;
+                if (note.Module != null && !finding.Module.Contains(note.Module, StringComparison.OrdinalIgnoreCase)) continue;
+                result.Add(new MatchedNote { Note = note, FindingTitle = finding.Title, FindingModule = finding.Module, FindingSeverity = finding.Severity });
+            }
+        }
+        return result;
+    }
+
+    public NoteStats GetStats()
+    {
+        var notes = Load();
+        var stats = new NoteStats { TotalNotes = notes.Count, PinnedNotes = notes.Count(n => n.Pinned) };
+        foreach (var cat in Enum.GetValues<NoteCategory>())
+        {
+            var count = notes.Count(n => n.Category == cat);
+            if (count > 0) stats.ByCategory[cat.ToString()] = count;
+        }
+        if (notes.Count > 0) { stats.OldestNote = notes.Min(n => n.CreatedAt); stats.NewestNote = notes.Max(n => n.CreatedAt); }
+        return stats;
+    }
+
+    public List<AuditNote> GetByCategory(NoteCategory category) => Load().Where(n => n.Category == category).ToList();
+    public List<AuditNote> GetPinned() => Load().Where(n => n.Pinned).ToList();
+
+    private List<AuditNote> Load()
+    {
+        if (_cache != null) return _cache;
+        if (!File.Exists(_filePath)) { _cache = []; return _cache; }
+        try { var json = File.ReadAllText(_filePath); _cache = JsonSerializer.Deserialize<List<AuditNote>>(json, JsonOpts) ?? []; }
+        catch { _cache = []; }
+        return _cache;
+    }
+
+    private void Save(List<AuditNote> notes)
+    {
+        _cache = notes;
+        var dir = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        File.WriteAllText(_filePath, JsonSerializer.Serialize(notes, JsonOpts));
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+}

--- a/tests/WinSentinel.Tests/Services/AuditNoteServiceTests.cs
+++ b/tests/WinSentinel.Tests/Services/AuditNoteServiceTests.cs
@@ -1,0 +1,98 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests.Services;
+
+public class AuditNoteServiceTests : IDisposable
+{
+    private readonly string _tempFile;
+    private readonly AuditNoteService _service;
+
+    public AuditNoteServiceTests()
+    {
+        _tempFile = Path.Combine(Path.GetTempPath(), $"winsentinel-notes-test-{Guid.NewGuid():N}.json");
+        _service = new AuditNoteService(_tempFile);
+    }
+
+    public void Dispose() { if (File.Exists(_tempFile)) File.Delete(_tempFile); }
+
+    [Fact] public void Add_CreatesNote()
+    {
+        var note = _service.Add("Windows Firewall", "Known issue");
+        Assert.Equal("Windows Firewall", note.FindingPattern);
+        Assert.Equal(NoteCategory.Comment, note.Category);
+        Assert.NotEmpty(note.Id);
+    }
+
+    [Fact] public void Add_WithCategory()
+    { Assert.Equal(NoteCategory.Deferred, _service.Add("SMBv1", "Deferred", NoteCategory.Deferred).Category); }
+
+    [Fact] public void Add_EmptyPattern_Throws()
+    { Assert.Throws<ArgumentException>(() => _service.Add("", "text")); }
+
+    [Fact] public void Add_EmptyText_Throws()
+    { Assert.Throws<ArgumentException>(() => _service.Add("p", "")); }
+
+    [Fact] public void GetAll_ReturnsAll()
+    { _service.Add("A", "a"); _service.Add("B", "b"); Assert.Equal(2, _service.GetAll().Count); }
+
+    [Fact] public void Get_ById()
+    { var n = _service.Add("T", "t"); Assert.Equal(n.Text, _service.Get(n.Id)!.Text); }
+
+    [Fact] public void Get_NotFound() { Assert.Null(_service.Get("x")); }
+
+    [Fact] public void Update_Text()
+    {
+        var n = _service.Add("P", "old");
+        var u = _service.Update(n.Id, newText: "new");
+        Assert.Equal("new", u!.Text); Assert.NotNull(u.UpdatedAt);
+    }
+
+    [Fact] public void Update_Category()
+    { var n = _service.Add("P", "t"); Assert.Equal(NoteCategory.Accepted, _service.Update(n.Id, newCategory: NoteCategory.Accepted)!.Category); }
+
+    [Fact] public void Update_NotFound() { Assert.Null(_service.Update("x", newText: "y")); }
+
+    [Fact] public void Remove_Works()
+    { var n = _service.Add("T", "t"); Assert.True(_service.Remove(n.Id)); Assert.Empty(_service.GetAll()); }
+
+    [Fact] public void Remove_NotFound() { Assert.False(_service.Remove("x")); }
+
+    [Fact] public void Clear_All()
+    { _service.Add("A", "a"); _service.Add("B", "b"); Assert.Equal(2, _service.Clear()); Assert.Empty(_service.GetAll()); }
+
+    [Fact] public void Search_ByText()
+    { _service.Add("F", "Known"); _service.Add("S", "Fix"); var r = _service.Search("known"); Assert.Single(r.Notes); Assert.Equal(2, r.TotalNotes); }
+
+    [Fact] public void Search_ByPattern()
+    { _service.Add("Firewall", "n"); Assert.Single(_service.Search("fire").Notes); }
+
+    [Fact] public void Match_Findings()
+    {
+        _service.Add("Firewall", "risk"); _service.Add("SMB", "defer");
+        var f = new List<(string, string, string)> { ("Windows Firewall disabled", "FW", "Critical"), ("AV outdated", "Def", "Warn") };
+        var m = _service.Match(f); Assert.Single(m); Assert.Equal("Windows Firewall disabled", m[0].FindingTitle);
+    }
+
+    [Fact] public void Match_ModuleFilter()
+    {
+        _service.Add("Firewall", "n", module: "Network");
+        var f = new List<(string, string, string)> { ("Firewall disabled", "FW", "Crit") };
+        Assert.Empty(_service.Match(f));
+    }
+
+    [Fact] public void Stats()
+    {
+        _service.Add("A", "a"); _service.Add("B", "b", NoteCategory.Accepted, pinned: true); _service.Add("C", "c", NoteCategory.Accepted);
+        var s = _service.GetStats(); Assert.Equal(3, s.TotalNotes); Assert.Equal(1, s.PinnedNotes); Assert.Equal(2, s.ByCategory["Accepted"]);
+    }
+
+    [Fact] public void GetByCategory()
+    { _service.Add("A", "a"); _service.Add("B", "b", NoteCategory.Deferred); Assert.Single(_service.GetByCategory(NoteCategory.Deferred)); }
+
+    [Fact] public void GetPinned()
+    { _service.Add("A", "a", pinned: true); _service.Add("B", "b"); Assert.Single(_service.GetPinned()); }
+
+    [Fact] public void Persistence()
+    { _service.Add("T", "persisted"); var s2 = new AuditNoteService(_tempFile); Assert.Single(s2.GetAll()); Assert.Equal("persisted", s2.GetAll()[0].Text); }
+}


### PR DESCRIPTION
## Audit Notes Feature

Adds the ability to annotate audit findings with persistent notes that survive across audit runs. Useful for tracking accepted risks, deferred fixes, false positives, and in-progress remediation.

### New CLI Commands

\\\ash
# Add a note for findings matching a pattern
winsentinel --notes add "Windows Firewall" --note-text "Accepted risk per policy" --note-category accepted

# List all notes
winsentinel --notes list

# Search notes
winsentinel --notes search "firewall"

# Update a note
winsentinel --notes update <id> --note-text "New text" --note-category deferred

# Remove / clear
winsentinel --notes remove <id>
winsentinel --notes clear

# View statistics
winsentinel --notes stats
\\\

### Categories
\comment\, \ccepted\, \deferred\, \inprogress\, \wontfix\, \alsepositive\

### Options
- \--note-module <module>\ — scope note to a specific module
- \--note-pin\ — pin important notes
- \--json\ / \--quiet\ / \--output\ — all standard output options work

### Files Changed
- **AuditNoteModels.cs** — data models (AuditNote, NoteCategory, MatchedNote, NoteSearchResult, NoteStats)
- **AuditNoteService.cs** — full CRUD + search + match + stats with JSON file persistence
- **CliParser.cs** — new \--notes\ command parsing with all sub-actions
- **Program.cs** — CLI handlers with colored console output
- **AuditNoteServiceTests.cs** — 21 unit tests, all passing

### Testing
All 21 new tests pass. Build succeeds with 0 errors.