### PR TITLE
feat: Finding Search CLI (--search)

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -74,6 +74,12 @@ public class CliOptions
     public int ScheduleOptimizeDays { get; set; } = 90;
     public int DigestHistoryDays { get; set; } = 30;
     public string DigestFormat { get; set; } = "text";
+    public string? SearchQuery { get; set; }
+    public string? SearchSeverityFilter { get; set; }
+    public string? SearchModuleFilter { get; set; }
+    public int SearchLimit { get; set; } = 50;
+    public bool SearchHighlight { get; set; } = true;
+    public bool SearchIncludeRemediation { get; set; }
 }
 
 public enum CliCommand
@@ -101,6 +107,7 @@ public enum CliCommand
     ScheduleOptimize,
     Digest,
     AttackPaths,
+    Search,
     Help,
     Version
 }
@@ -402,6 +409,45 @@ public static class CliParser
 
                 case "--attack-paths":
                     options.Command = CliCommand.AttackPaths;
+                    break;
+
+                case "--search":
+                    options.Command = CliCommand.Search;
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith("-"))
+                    {
+                        options.SearchQuery = args[++i];
+                    }
+                    else
+                    {
+                        options.Error = "Missing search query. Usage: --search <query>";
+                        return options;
+                    }
+                    break;
+
+                case "--search-severity":
+                    if (!TryConsumeArg(args, ref i, "--search-severity", out var sSev, out var sSevErr))
+                    { options.Error = sSevErr; return options; }
+                    options.SearchSeverityFilter = sSev;
+                    break;
+
+                case "--search-module":
+                    if (!TryConsumeArg(args, ref i, "--search-module", out var sMod, out var sModErr))
+                    { options.Error = sModErr; return options; }
+                    options.SearchModuleFilter = sMod;
+                    break;
+
+                case "--search-limit":
+                    if (!TryConsumeInt(args, ref i, "--search-limit", 1, 500, out var sLimit, out var sLimErr))
+                    { options.Error = sLimErr; return options; }
+                    options.SearchLimit = sLimit;
+                    break;
+
+                case "--no-highlight":
+                    options.SearchHighlight = false;
+                    break;
+
+                case "--show-remediation":
+                    options.SearchIncludeRemediation = true;
                     break;
 
                 case "--digest-days":

--- a/src/WinSentinel.Cli/ConsoleFormatter.Search.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Search.cs
@@ -1,0 +1,195 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Cli;
+
+public static partial class ConsoleFormatter
+{
+    public static void PrintSearchResults(SearchResult result, bool highlight, bool showRemediation)
+    {
+        var orig = Console.ForegroundColor;
+
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("  ╔══════════════════════════════════════════════╗");
+        Console.WriteLine("  ║         🔍  Finding Search Results          ║");
+        Console.WriteLine("  ╚══════════════════════════════════════════════╝");
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+
+        // Search info
+        Console.Write("  Query:    ");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine($"\"{result.Query}\"");
+        Console.ForegroundColor = orig;
+
+        Console.Write("  Matches:  ");
+        Console.ForegroundColor = result.Matches.Count > 0 ? ConsoleColor.Green : ConsoleColor.Yellow;
+        Console.Write(result.Matches.Count);
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine($" of {result.TotalFindings} total findings");
+        Console.ForegroundColor = orig;
+
+        if (result.SeverityFilter != null)
+        {
+            Console.Write("  Filter:   ");
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"severity={result.SeverityFilter}");
+            Console.ForegroundColor = orig;
+        }
+        if (result.ModuleFilter != null)
+        {
+            Console.Write("  Filter:   ");
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"module={result.ModuleFilter}");
+            Console.ForegroundColor = orig;
+        }
+
+        Console.WriteLine();
+
+        if (result.Matches.Count == 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("  No findings matched your search query.");
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine("  Try a broader query, or remove filters.");
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+            return;
+        }
+
+        // Severity breakdown
+        if (result.SeverityBreakdown.Count > 0)
+        {
+            Console.Write("  ");
+            foreach (var (sev, count) in result.SeverityBreakdown.OrderByDescending(kv => SevRank(kv.Key)))
+            {
+                Console.ForegroundColor = SevColor(sev);
+                Console.Write($"{count} {sev.ToLower()}  ");
+            }
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+            Console.WriteLine();
+        }
+
+        // Results
+        for (int i = 0; i < result.Matches.Count; i++)
+        {
+            var match = result.Matches[i];
+            var finding = match.Finding;
+            var sevColor = SevColor(finding.Severity.ToString());
+
+            // Index + severity badge
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write($"  {i + 1,3}. ");
+            Console.ForegroundColor = sevColor;
+            Console.Write($"[{finding.Severity}]");
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.Write(" ");
+
+            // Title with highlighting
+            if (highlight)
+            {
+                var segments = FindingSearchService.HighlightMatches(finding.Title ?? "", result.Query);
+                foreach (var (text, isMatch) in segments)
+                {
+                    Console.ForegroundColor = isMatch ? ConsoleColor.Yellow : ConsoleColor.White;
+                    Console.Write(text);
+                }
+            }
+            else
+            {
+                Console.Write(finding.Title);
+            }
+            Console.WriteLine();
+
+            // Module + matched fields
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write($"       Module: {match.ModuleCategory}");
+            Console.Write($"  |  Matched: {string.Join(", ", match.MatchedFields)}");
+            Console.Write($"  |  Score: {match.RelevanceScore}");
+            Console.WriteLine();
+
+            // Description with highlighting
+            if (!string.IsNullOrEmpty(finding.Description))
+            {
+                Console.Write("       ");
+                if (highlight)
+                {
+                    var segments = FindingSearchService.HighlightMatches(finding.Description, result.Query);
+                    var totalLen = 0;
+                    foreach (var (text, isMatch) in segments)
+                    {
+                        var remaining = 120 - totalLen;
+                        if (remaining <= 0) break;
+                        var truncated = text.Length > remaining ? text[..remaining] + "..." : text;
+                        Console.ForegroundColor = isMatch ? ConsoleColor.Yellow : ConsoleColor.DarkGray;
+                        Console.Write(truncated);
+                        totalLen += truncated.Length;
+                    }
+                }
+                else
+                {
+                    Console.ForegroundColor = ConsoleColor.DarkGray;
+                    var desc = finding.Description.Length > 120
+                        ? finding.Description[..120] + "..."
+                        : finding.Description;
+                    Console.Write(desc);
+                }
+                Console.WriteLine();
+            }
+
+            // Remediation (optional)
+            if (showRemediation && !string.IsNullOrEmpty(finding.Remediation))
+            {
+                Console.ForegroundColor = ConsoleColor.DarkCyan;
+                var rem = finding.Remediation.Length > 120
+                    ? finding.Remediation[..120] + "..."
+                    : finding.Remediation;
+                Console.WriteLine($"       → {rem}");
+            }
+
+            // Fix command
+            if (!string.IsNullOrEmpty(finding.FixCommand))
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGreen;
+                Console.WriteLine($"       $ {finding.FixCommand}");
+            }
+
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+        }
+
+        // Module breakdown
+        if (result.ModuleBreakdown.Count > 1)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.Write("  Modules: ");
+            foreach (var (mod, count) in result.ModuleBreakdown.OrderByDescending(kv => kv.Value))
+            {
+                Console.Write($"{mod}({count}) ");
+            }
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+            Console.WriteLine();
+        }
+    }
+
+    private static ConsoleColor SevColor(string severity) => severity.ToLowerInvariant() switch
+    {
+        "critical" => ConsoleColor.Red,
+        "warning" => ConsoleColor.Yellow,
+        "info" => ConsoleColor.Cyan,
+        "pass" => ConsoleColor.Green,
+        _ => ConsoleColor.Gray
+    };
+
+    private static int SevRank(string severity) => severity.ToLowerInvariant() switch
+    {
+        "critical" => 4,
+        "warning" => 3,
+        "info" => 2,
+        "pass" => 1,
+        _ => 0
+    };
+}

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -281,6 +281,7 @@ public static partial class ConsoleFormatter
         WriteHelpEntry("    --policy <action>    ", "Security Policy as Code (export/import/validate/diff)");
         WriteHelpEntry("    --threats            ", "STRIDE threat model from audit findings");
         WriteHelpEntry("    --attack-paths       ", "Kill chain attack path analysis with chokepoints");
+        WriteHelpEntry("    --search <query>     ", "Search findings by keyword with relevance ranking");
         WriteHelpEntry("    --help, -h           ", "Show this help message");
         WriteHelpEntry("    --version, -v        ", "Show version information");
         Console.WriteLine();

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -42,6 +42,7 @@ return options.Command switch
     CliCommand.ScheduleOptimize => HandleScheduleOptimize(options),
     CliCommand.Digest => await HandleDigest(options),
     CliCommand.AttackPaths => await HandleAttackPaths(options),
+    CliCommand.Search => await HandleSearch(options),
     _ => HandleHelp()
 };
 
@@ -2537,4 +2538,81 @@ static async Task<int> HandleAttackPaths(CliOptions options)
     historyService.SaveAuditResult(report);
 
     return 0;
+}
+
+// ── Finding Search ───────────────────────────────────────────────
+
+static async Task<int> HandleSearch(CliOptions options)
+{
+    var engine = BuildEngine(options.ModulesFilter);
+    var sw = Stopwatch.StartNew();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintBanner();
+        Console.WriteLine($"  Searching findings for \"{options.SearchQuery}\"...");
+        Console.WriteLine();
+    }
+
+    var progress = options.Quiet || options.Json
+        ? null
+        : new Progress<(string module, int current, int total)>(p =>
+            ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
+
+    var report = await engine.RunFullAuditAsync(progress);
+    sw.Stop();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintProgressDone(engine.Modules.Count, sw.Elapsed);
+    }
+
+    var searchService = new FindingSearchService();
+    var searchOptions = new SearchOptions
+    {
+        Query = options.SearchQuery!,
+        SeverityFilter = options.SearchSeverityFilter,
+        ModuleFilter = options.SearchModuleFilter,
+        Limit = options.SearchLimit
+    };
+
+    var result = searchService.Search(report, searchOptions);
+
+    if (options.Json)
+    {
+        var jsonResult = new
+        {
+            query = result.Query,
+            totalFindings = result.TotalFindings,
+            matchCount = result.Matches.Count,
+            severityFilter = result.SeverityFilter,
+            moduleFilter = result.ModuleFilter,
+            severityBreakdown = result.SeverityBreakdown,
+            moduleBreakdown = result.ModuleBreakdown,
+            matches = result.Matches.Select(m => new
+            {
+                title = m.Finding.Title,
+                severity = m.Finding.Severity.ToString(),
+                module = m.ModuleCategory,
+                description = m.Finding.Description,
+                remediation = m.Finding.Remediation,
+                fixCommand = m.Finding.FixCommand,
+                relevanceScore = m.RelevanceScore,
+                matchedFields = m.MatchedFields
+            })
+        };
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var json = JsonSerializer.Serialize(jsonResult, jsonOptions);
+        WriteOutput(json, options.OutputFile);
+    }
+    else
+    {
+        ConsoleFormatter.PrintSearchResults(result, options.SearchHighlight, options.SearchIncludeRemediation);
+    }
+
+    return result.Matches.Count > 0 ? 0 : 1;
 }

--- a/src/WinSentinel.Core/Services/FindingSearchService.cs
+++ b/src/WinSentinel.Core/Services/FindingSearchService.cs
@@ -1,0 +1,220 @@
+using System.Text.RegularExpressions;
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+/// <summary>
+/// Searches audit findings by keyword with filtering and relevance scoring.
+/// </summary>
+public class FindingSearchService
+{
+    /// <summary>
+    /// Search across all findings in a security report.
+    /// </summary>
+    public SearchResult Search(SecurityReport report, SearchOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentNullException.ThrowIfNull(options);
+
+        if (string.IsNullOrWhiteSpace(options.Query))
+            return new SearchResult { Query = options.Query ?? "", Matches = new List<SearchMatch>() };
+
+        var query = options.Query.Trim();
+        var queryLower = query.ToLowerInvariant();
+        var queryWords = queryLower.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        var matches = new List<SearchMatch>();
+
+        foreach (var auditResult in report.Results)
+        {
+            foreach (var finding in auditResult.Findings)
+            {
+                // Apply severity filter
+                if (options.SeverityFilter != null &&
+                    !finding.Severity.ToString().Equals(options.SeverityFilter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                // Apply module filter
+                if (!string.IsNullOrEmpty(options.ModuleFilter) &&
+                    !auditResult.Category.Contains(options.ModuleFilter, StringComparison.OrdinalIgnoreCase) &&
+                    !(finding.Category ?? "").Contains(options.ModuleFilter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var score = CalculateRelevance(finding, auditResult.Category, queryWords, queryLower);
+
+                if (score > 0)
+                {
+                    var matchFields = GetMatchFields(finding, auditResult.Category, queryLower);
+                    matches.Add(new SearchMatch
+                    {
+                        Finding = finding,
+                        ModuleCategory = auditResult.Category,
+                        RelevanceScore = score,
+                        MatchedFields = matchFields
+                    });
+                }
+            }
+        }
+
+        // Sort by relevance (highest first), then severity
+        var sorted = matches
+            .OrderByDescending(m => m.RelevanceScore)
+            .ThenByDescending(m => SeverityRank(m.Finding.Severity))
+            .Take(options.Limit)
+            .ToList();
+
+        return new SearchResult
+        {
+            Query = query,
+            TotalFindings = report.TotalFindings,
+            Matches = sorted,
+            SeverityFilter = options.SeverityFilter,
+            ModuleFilter = options.ModuleFilter,
+            SeverityBreakdown = sorted
+                .GroupBy(m => m.Finding.Severity)
+                .ToDictionary(g => g.Key.ToString(), g => g.Count()),
+            ModuleBreakdown = sorted
+                .GroupBy(m => m.ModuleCategory)
+                .ToDictionary(g => g.Key, g => g.Count())
+        };
+    }
+
+    private static int CalculateRelevance(Finding finding, string category, string[] queryWords, string queryLower)
+    {
+        int score = 0;
+        var titleLower = (finding.Title ?? "").ToLowerInvariant();
+        var descLower = (finding.Description ?? "").ToLowerInvariant();
+        var remLower = (finding.Remediation ?? "").ToLowerInvariant();
+        var catLower = category.ToLowerInvariant();
+        var moduleLower = (finding.Category ?? "").ToLowerInvariant();
+
+        // Exact phrase match in title = highest relevance
+        if (titleLower.Contains(queryLower))
+            score += 100;
+
+        // Exact phrase match in description
+        if (descLower.Contains(queryLower))
+            score += 50;
+
+        // Exact phrase match in remediation
+        if (remLower.Contains(queryLower))
+            score += 20;
+
+        // Exact phrase match in category/module
+        if (catLower.Contains(queryLower) || moduleLower.Contains(queryLower))
+            score += 30;
+
+        // Individual word matches (for multi-word queries)
+        if (queryWords.Length > 1)
+        {
+            foreach (var word in queryWords)
+            {
+                if (word.Length < 2) continue;
+                if (titleLower.Contains(word)) score += 15;
+                if (descLower.Contains(word)) score += 8;
+                if (remLower.Contains(word)) score += 3;
+                if (catLower.Contains(word) || moduleLower.Contains(word)) score += 5;
+            }
+        }
+
+        // Severity boost: critical findings rank higher
+        if (score > 0)
+        {
+            score += SeverityRank(finding.Severity) * 2;
+        }
+
+        return score;
+    }
+
+    private static List<string> GetMatchFields(Finding finding, string category, string queryLower)
+    {
+        var fields = new List<string>();
+        if ((finding.Title ?? "").Contains(queryLower, StringComparison.OrdinalIgnoreCase))
+            fields.Add("title");
+        if ((finding.Description ?? "").Contains(queryLower, StringComparison.OrdinalIgnoreCase))
+            fields.Add("description");
+        if ((finding.Remediation ?? "").Contains(queryLower, StringComparison.OrdinalIgnoreCase))
+            fields.Add("remediation");
+        if (category.Contains(queryLower, StringComparison.OrdinalIgnoreCase) ||
+            (finding.Category ?? "").Contains(queryLower, StringComparison.OrdinalIgnoreCase))
+            fields.Add("module");
+
+        // If no exact phrase matches, note it's a partial/word match
+        if (fields.Count == 0)
+            fields.Add("partial");
+
+        return fields;
+    }
+
+    private static int SeverityRank(Severity severity) => severity switch
+    {
+        Severity.Critical => 4,
+        Severity.Warning => 3,
+        Severity.Info => 2,
+        Severity.Pass => 1,
+        _ => 0
+    };
+
+    /// <summary>
+    /// Highlight query matches in text for console display.
+    /// Returns segments with isMatch flags for the caller to colorize.
+    /// </summary>
+    public static List<(string text, bool isMatch)> HighlightMatches(string text, string query)
+    {
+        if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(query))
+            return new List<(string, bool)> { (text ?? "", false) };
+
+        var segments = new List<(string text, bool isMatch)>();
+        var idx = 0;
+        var textLower = text.ToLowerInvariant();
+        var queryLower = query.ToLowerInvariant();
+
+        while (idx < text.Length)
+        {
+            var matchIdx = textLower.IndexOf(queryLower, idx, StringComparison.Ordinal);
+            if (matchIdx < 0)
+            {
+                segments.Add((text[idx..], false));
+                break;
+            }
+
+            if (matchIdx > idx)
+                segments.Add((text[idx..matchIdx], false));
+
+            segments.Add((text[matchIdx..(matchIdx + query.Length)], true));
+            idx = matchIdx + query.Length;
+        }
+
+        return segments;
+    }
+}
+
+/// <summary>Options for finding search.</summary>
+public class SearchOptions
+{
+    public string Query { get; set; } = "";
+    public string? SeverityFilter { get; set; }
+    public string? ModuleFilter { get; set; }
+    public int Limit { get; set; } = 50;
+}
+
+/// <summary>A single search match with relevance info.</summary>
+public class SearchMatch
+{
+    public Finding Finding { get; set; } = null!;
+    public string ModuleCategory { get; set; } = "";
+    public int RelevanceScore { get; set; }
+    public List<string> MatchedFields { get; set; } = new();
+}
+
+/// <summary>Search results with metadata.</summary>
+public class SearchResult
+{
+    public string Query { get; set; } = "";
+    public int TotalFindings { get; set; }
+    public List<SearchMatch> Matches { get; set; } = new();
+    public string? SeverityFilter { get; set; }
+    public string? ModuleFilter { get; set; }
+    public Dictionary<string, int> SeverityBreakdown { get; set; } = new();
+    public Dictionary<string, int> ModuleBreakdown { get; set; } = new();
+}

--- a/tests/WinSentinel.Tests/FindingSearchServiceTests.cs
+++ b/tests/WinSentinel.Tests/FindingSearchServiceTests.cs
@@ -1,0 +1,252 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests;
+
+public class FindingSearchServiceTests
+{
+    private static SecurityReport CreateTestReport()
+    {
+        var report = new SecurityReport();
+        report.Results.Add(new AuditResult
+        {
+            ModuleName = "FirewallAudit",
+            Category = "Firewall",
+            Findings = new List<Finding>
+            {
+                new()
+                {
+                    Title = "Windows Firewall is disabled",
+                    Description = "The Windows Defender Firewall is currently turned off for the public profile.",
+                    Severity = Severity.Critical,
+                    Remediation = "Enable Windows Firewall via Control Panel or PowerShell.",
+                    FixCommand = "Set-NetFirewallProfile -Profile Public -Enabled True",
+                    Category = "Firewall"
+                },
+                new()
+                {
+                    Title = "Inbound rules allow all traffic",
+                    Description = "Several inbound firewall rules are configured to allow all traffic.",
+                    Severity = Severity.Warning,
+                    Category = "Firewall"
+                }
+            }
+        });
+        report.Results.Add(new AuditResult
+        {
+            ModuleName = "UpdateAudit",
+            Category = "Updates",
+            Findings = new List<Finding>
+            {
+                new()
+                {
+                    Title = "System updates are outdated",
+                    Description = "Windows Update has not checked for updates in 45 days.",
+                    Severity = Severity.Warning,
+                    Remediation = "Run Windows Update to install pending patches.",
+                    Category = "Updates"
+                },
+                new()
+                {
+                    Title = "Automatic updates disabled",
+                    Description = "Windows Update automatic download and install is disabled.",
+                    Severity = Severity.Info,
+                    Category = "Updates"
+                }
+            }
+        });
+        return report;
+    }
+
+    [Fact]
+    public void Search_FindsMatchingTitle()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions { Query = "firewall" });
+
+        Assert.True(result.Matches.Count >= 2);
+        Assert.All(result.Matches.Take(2), m =>
+            Assert.Contains("Firewall", m.ModuleCategory, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Search_FindsMatchInDescription()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions { Query = "45 days" });
+
+        Assert.Single(result.Matches);
+        Assert.Contains("outdated", result.Matches[0].Finding.Title, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Search_FiltersBySeverity()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions
+        {
+            Query = "firewall",
+            SeverityFilter = "Critical"
+        });
+
+        Assert.Single(result.Matches);
+        Assert.Equal(Severity.Critical, result.Matches[0].Finding.Severity);
+    }
+
+    [Fact]
+    public void Search_FiltersByModule()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions
+        {
+            Query = "disabled",
+            ModuleFilter = "Updates"
+        });
+
+        Assert.Single(result.Matches);
+        Assert.Contains("Updates", result.Matches[0].ModuleCategory);
+    }
+
+    [Fact]
+    public void Search_RespectsLimit()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions
+        {
+            Query = "firewall",
+            Limit = 1
+        });
+
+        Assert.Single(result.Matches);
+    }
+
+    [Fact]
+    public void Search_ReturnsEmptyForNoMatch()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions { Query = "xyznonexistent" });
+
+        Assert.Empty(result.Matches);
+    }
+
+    [Fact]
+    public void Search_RanksHigherRelevanceFirst()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        // "disabled" appears in title for two findings: firewall and updates
+        var result = service.Search(report, new SearchOptions { Query = "disabled" });
+
+        Assert.True(result.Matches.Count >= 2);
+        // Critical finding should rank higher
+        Assert.True(result.Matches[0].RelevanceScore >= result.Matches[1].RelevanceScore);
+    }
+
+    [Fact]
+    public void Search_IncludesSeverityBreakdown()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions { Query = "disabled" });
+
+        Assert.NotEmpty(result.SeverityBreakdown);
+    }
+
+    [Fact]
+    public void Search_IncludesModuleBreakdown()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions { Query = "disabled" });
+
+        Assert.NotEmpty(result.ModuleBreakdown);
+    }
+
+    [Fact]
+    public void HighlightMatches_SplitsCorrectly()
+    {
+        var segments = FindingSearchService.HighlightMatches("Windows Firewall is disabled", "firewall");
+
+        Assert.Equal(3, segments.Count);
+        Assert.False(segments[0].isMatch); // "Windows "
+        Assert.True(segments[1].isMatch);  // "Firewall"
+        Assert.False(segments[2].isMatch); // " is disabled"
+    }
+
+    [Fact]
+    public void HighlightMatches_EmptyQuery()
+    {
+        var segments = FindingSearchService.HighlightMatches("some text", "");
+
+        Assert.Single(segments);
+        Assert.False(segments[0].isMatch);
+    }
+
+    [Fact]
+    public void Search_EmptyQuery_ReturnsEmpty()
+    {
+        var service = new FindingSearchService();
+        var report = CreateTestReport();
+
+        var result = service.Search(report, new SearchOptions { Query = "" });
+
+        Assert.Empty(result.Matches);
+    }
+
+    [Fact]
+    public void CliParser_ParsesSearchCommand()
+    {
+        var options = WinSentinel.Cli.CliParser.Parse(new[] { "--search", "firewall" });
+
+        Assert.Equal(WinSentinel.Cli.CliCommand.Search, options.Command);
+        Assert.Equal("firewall", options.SearchQuery);
+        Assert.Null(options.Error);
+    }
+
+    [Fact]
+    public void CliParser_ParsesSearchWithFilters()
+    {
+        var options = WinSentinel.Cli.CliParser.Parse(new[]
+        {
+            "--search", "disabled",
+            "--search-severity", "Critical",
+            "--search-module", "Firewall",
+            "--search-limit", "10",
+            "--no-highlight",
+            "--show-remediation"
+        });
+
+        Assert.Equal(WinSentinel.Cli.CliCommand.Search, options.Command);
+        Assert.Equal("disabled", options.SearchQuery);
+        Assert.Equal("Critical", options.SearchSeverityFilter);
+        Assert.Equal("Firewall", options.SearchModuleFilter);
+        Assert.Equal(10, options.SearchLimit);
+        Assert.False(options.SearchHighlight);
+        Assert.True(options.SearchIncludeRemediation);
+        Assert.Null(options.Error);
+    }
+
+    [Fact]
+    public void CliParser_SearchRequiresQuery()
+    {
+        var options = WinSentinel.Cli.CliParser.Parse(new[] { "--search" });
+
+        Assert.NotNull(options.Error);
+        Assert.Contains("Missing search query", options.Error);
+    }
+}


### PR DESCRIPTION
## Finding Search CLI

Search across all audit findings by keyword with relevance-based ranking.

### Features
- Relevance scoring — title matches rank higher than description, with severity boost
- Match highlighting — query terms highlighted in console output
- Severity/module filters with --search-severity and --search-module
- Result limit with --search-limit N (default 50)
- JSON output with --json
- Remediation display with --show-remediation
- Severity and module breakdown summary

### Files Changed
- FindingSearchService.cs — core search logic with relevance scoring
- ConsoleFormatter.Search.cs — colorized console output with highlighting
- CliParser.cs — new --search command and filter options
- Program.cs — HandleSearch handler
- FindingSearchServiceTests.cs — 15 unit tests

All 15 new tests pass. Build clean with 0 errors.
