### PR TITLE
feat: add --module-info command to list all audit modules

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -100,6 +100,7 @@ public enum CliCommand
     Threats,
     ScheduleOptimize,
     Digest,
+    ModuleInfo,
     Help,
     Version
 }
@@ -433,6 +434,10 @@ public static class CliParser
 
                 case "--digest":
                     options.Command = CliCommand.Digest;
+                    break;
+
+                case "--module-info":
+                    options.Command = CliCommand.ModuleInfo;
                     break;
 
                 case "--digest-days":

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -316,6 +316,10 @@ public static partial class ConsoleFormatter
         Console.ForegroundColor = original;
         Console.WriteLine("STRIDE threat model from audit findings");
         Console.ForegroundColor = ConsoleColor.White;
+        Console.Write("    --module-info        ");
+        Console.ForegroundColor = original;
+        Console.WriteLine("List all available audit modules with descriptions");
+        Console.ForegroundColor = ConsoleColor.White;
         Console.Write("    --help, -h           ");
         Console.ForegroundColor = original;
         Console.WriteLine("Show this help message");

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -41,6 +41,7 @@ return options.Command switch
     CliCommand.Threats => await HandleThreats(options),
     CliCommand.ScheduleOptimize => HandleScheduleOptimize(options),
     CliCommand.Digest => await HandleDigest(options),
+    CliCommand.ModuleInfo => HandleModuleInfo(options),
     _ => HandleHelp()
 };
 
@@ -2413,6 +2414,120 @@ static int HandleScheduleOptimize(CliOptions options)
 
     ConsoleFormatter.PrintScheduleOptimizeResult(result);
     return 0;
+}
+
+// ── Module Info ──────────────────────────────────────────────────────
+
+static int HandleModuleInfo(CliOptions options)
+{
+    var modules = GetAllModules();
+
+    if (options.Json)
+    {
+        var jsonModules = modules.Select(m => new
+        {
+            name = m.Name,
+            category = m.Category,
+            description = m.Description,
+        });
+        var jsonOptions = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+        var json = JsonSerializer.Serialize(new
+        {
+            totalModules = modules.Count,
+            modules = jsonModules
+        }, jsonOptions);
+        WriteOutput(json, options.OutputFile);
+        return 0;
+    }
+
+    var orig = Console.ForegroundColor;
+
+    Console.WriteLine();
+    Console.ForegroundColor = ConsoleColor.Cyan;
+    Console.WriteLine("  ╔══════════════════════════════════════════════╗");
+    Console.WriteLine("  ║       🛡️  WinSentinel Audit Modules         ║");
+    Console.WriteLine("  ╚══════════════════════════════════════════════╝");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    Console.ForegroundColor = ConsoleColor.White;
+    Console.WriteLine($"  {modules.Count} modules available");
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.WriteLine("  ──────────────────────────────────────────────────────────────");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    // Group by first letter of category for visual grouping
+    var grouped = modules
+        .OrderBy(m => m.Category, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    var maxCatLen = grouped.Max(m => m.Category.Length);
+
+    foreach (var mod in grouped)
+    {
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.Write($"  {mod.Category.PadRight(maxCatLen + 2)}");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write(mod.Name);
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine();
+        Console.Write($"  {"".PadRight(maxCatLen + 2)}");
+        Console.WriteLine(mod.Description);
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+    }
+
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.WriteLine("  ──────────────────────────────────────────────────────────────");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+    Console.WriteLine("  Usage:");
+    Console.ForegroundColor = ConsoleColor.Cyan;
+    Console.WriteLine("    winsentinel --audit                       Run all modules");
+    Console.WriteLine("    winsentinel --audit -m firewall,network   Run specific modules");
+    Console.WriteLine("    winsentinel --module-info --json          Machine-readable list");
+    Console.ForegroundColor = orig;
+    Console.WriteLine();
+
+    return 0;
+}
+
+static List<IAuditModule> GetAllModules()
+{
+    return new List<IAuditModule>
+    {
+        new AccountAudit(),
+        new AppSecurityAudit(),
+        new BackupAudit(),
+        new BluetoothAudit(),
+        new BrowserAudit(),
+        new CertificateAudit(),
+        new CredentialExposureAudit(),
+        new DefenderAudit(),
+        new DnsAudit(),
+        new DriverAudit(),
+        new EncryptionAudit(),
+        new EnvironmentAudit(),
+        new EventLogAudit(),
+        new FirewallAudit(),
+        new GroupPolicyAudit(),
+        new NetworkAudit(),
+        new PowerShellAudit(),
+        new PrivacyAudit(),
+        new ProcessAudit(),
+        new RegistryAudit(),
+        new RemoteAccessAudit(),
+        new ScheduledTaskAudit(),
+        new ServiceAudit(),
+        new SmbShareAudit(),
+        new SoftwareInventoryAudit(),
+        new StartupAudit(),
+        new SystemAudit(),
+        new UpdateAudit(),
+        new VirtualizationAudit(),
+        new WifiAudit(),
+    };
 }
 
 // ── Digest ────────────────────────────────────────────────────────

--- a/tests/WinSentinel.Tests/Cli/CliParserTests.cs
+++ b/tests/WinSentinel.Tests/Cli/CliParserTests.cs
@@ -1164,4 +1164,21 @@ public class CliParserTests
         Assert.Equal(BadgeBadgeAction.None, options.BadgeAction);
         Assert.Null(options.BadgeStyle);
     }
+
+    [Fact]
+    public void Parse_ModuleInfo_ReturnsModuleInfoCommand()
+    {
+        var result = CliParser.Parse(["--module-info"]);
+        Assert.Equal(CliCommand.ModuleInfo, result.Command);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public void Parse_ModuleInfo_WithJson_SetsJsonFlag()
+    {
+        var result = CliParser.Parse(["--module-info", "--json"]);
+        Assert.Equal(CliCommand.ModuleInfo, result.Command);
+        Assert.True(result.Json);
+        Assert.Null(result.Error);
+    }
 }


### PR DESCRIPTION
## What

Adds a new \--module-info\ CLI command that displays all 30 available audit modules with their names, categories, and descriptions.

## Usage

\\\ash
# Console output with formatted table
winsentinel --module-info

# JSON output for scripting/tooling
winsentinel --module-info --json

# Save to file
winsentinel --module-info --json -o modules.json
\\\

## Changes

- **CliParser**: Added \--module-info\ flag → \CliCommand.ModuleInfo\
- **Program.cs**: Added \HandleModuleInfo()\ with console + JSON output, and \GetAllModules()\ helper listing all 30 audit modules
- **ConsoleFormatter**: Added help text entry
- **Tests**: 2 new parser tests for \--module-info\ and \--module-info --json\

## Why

Users need a way to discover what audit modules are available, especially since the \--modules\ filter flag requires knowing module names. This provides a catalog with descriptions.