### PR TITLE
fix: replace 102 empty catch blocks with diagnostic logging

### DIFF
--- a/src/WinSentinel.Agent/AgentService.cs
+++ b/src/WinSentinel.Agent/AgentService.cs
@@ -96,7 +96,7 @@ public class AgentService : BackgroundService
         {
             await Task.Delay(Timeout.Infinite, stoppingToken);
         }
-        catch (OperationCanceledException) { }
+        catch (OperationCanceledException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AgentService: {ex.GetType().Name} - {ex.Message}"); }
 
         // Shutdown
         _logger.LogInformation("WinSentinel Agent shutting down...");

--- a/src/WinSentinel.Agent/Modules/ClipboardMonitorModule.cs
+++ b/src/WinSentinel.Agent/Modules/ClipboardMonitorModule.cs
@@ -60,8 +60,8 @@ public partial class ClipboardMonitorModule : IAgentModule
         if (_monitorTask != null)
         {
             try { await _monitorTask.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken); }
-            catch (OperationCanceledException) { }
-            catch (TimeoutException) { }
+            catch (OperationCanceledException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ClipboardMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
+            catch (TimeoutException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ClipboardMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
         }
         _cts?.Dispose();
         _logger.LogInformation("[ClipboardMonitor] Stopped");

--- a/src/WinSentinel.Agent/Modules/EventLogMonitorModule.cs
+++ b/src/WinSentinel.Agent/Modules/EventLogMonitorModule.cs
@@ -1224,7 +1224,7 @@ public class EventLogMonitorModule : IAgentModule
                 return record.Properties[index]?.Value?.ToString();
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EventLogMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
         return null;
     }
 

--- a/src/WinSentinel.Agent/Modules/NetworkMonitorModule.cs
+++ b/src/WinSentinel.Agent/Modules/NetworkMonitorModule.cs
@@ -152,7 +152,7 @@ public class NetworkMonitorModule : IAgentModule
         if (_monitorTask != null)
         {
             try { await _monitorTask; }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] NetworkMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         _knownListeningPorts.Clear();
@@ -672,12 +672,12 @@ public class NetworkMonitorModule : IAgentModule
                             using var proc = Process.GetProcessById(pid);
                             return proc.ProcessName;
                         }
-                        catch { }
+                        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] NetworkMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
                     }
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] NetworkMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
 
         return null;
     }
@@ -694,7 +694,7 @@ public class NetworkMonitorModule : IAgentModule
                 return proc.MainModule?.FileName;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] NetworkMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
         return null;
     }
 
@@ -753,7 +753,7 @@ public class NetworkMonitorModule : IAgentModule
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] NetworkMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
 
         return null;
     }
@@ -780,7 +780,7 @@ public class NetworkMonitorModule : IAgentModule
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] NetworkMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
         return null;
     }
 

--- a/src/WinSentinel.Agent/Modules/ProcessMonitorModule.cs
+++ b/src/WinSentinel.Agent/Modules/ProcessMonitorModule.cs
@@ -281,7 +281,7 @@ public class ProcessMonitorModule : IAgentModule
                     commandLine = obj["CommandLine"]?.ToString();
                 }
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ProcessMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
 
             // Get parent process name
             parentName = GetProcessName(parentId);
@@ -352,7 +352,7 @@ public class ProcessMonitorModule : IAgentModule
             var processId = Convert.ToInt32(e.NewEvent["ProcessID"] ?? 0);
             _logger.LogTrace("Process stopped: {Name} (PID {Pid})", processName, processId);
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ProcessMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
     }
 
     // ── Threat Analysis Engine ──
@@ -693,7 +693,7 @@ public class ProcessMonitorModule : IAgentModule
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ProcessMonitorModule: {ex.GetType().Name} - {ex.Message}"); }
         return null;
     }
 

--- a/src/WinSentinel.Agent/Services/AutoRemediator.cs
+++ b/src/WinSentinel.Agent/Services/AutoRemediator.cs
@@ -212,7 +212,7 @@ public class AutoRemediator
         {
             using var proc = Process.GetProcessById(processId);
             var exePath = "";
-            try { exePath = proc.MainModule?.FileName ?? ""; } catch { }
+            try { exePath = proc.MainModule?.FileName ?? ""; } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AutoRemediator: {ex.GetType().Name} - {ex.Message}"); }
 
             proc.Kill(entireProcessTree: true);
             record.Success = true;

--- a/src/WinSentinel.Agent/Services/IpcServer.cs
+++ b/src/WinSentinel.Agent/Services/IpcServer.cs
@@ -144,7 +144,7 @@ public class IpcServer : BackgroundService
                 }
             }
         }
-        catch (OperationCanceledException) { }
+        catch (OperationCanceledException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] IpcServer: {ex.GetType().Name} - {ex.Message}"); }
         catch (IOException) { /* Client disconnected */ }
         catch (Exception ex)
         {

--- a/src/WinSentinel.Agent/Services/ScheduledAuditModule.cs
+++ b/src/WinSentinel.Agent/Services/ScheduledAuditModule.cs
@@ -54,7 +54,7 @@ public class ScheduledAuditModule : IAgentModule
         if (_runLoop != null)
         {
             try { await _runLoop; }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ScheduledAuditModule: {ex.GetType().Name} - {ex.Message}"); }
         }
     }
 

--- a/src/WinSentinel.App/Services/AgentConnectionService.cs
+++ b/src/WinSentinel.App/Services/AgentConnectionService.cs
@@ -286,7 +286,7 @@ public class AgentConnectionService : INotifyPropertyChanged, IDisposable
                     await ConnectAsync();
                 }
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AgentConnectionService: {ex.GetType().Name} - {ex.Message}"); }
         });
     }
 

--- a/src/WinSentinel.App/Services/TrayIconService.cs
+++ b/src/WinSentinel.App/Services/TrayIconService.cs
@@ -353,7 +353,7 @@ public sealed class TrayIconService : IDisposable
                 if (exeIcon != null) return exeIcon;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] TrayIconService: {ex.GetType().Name} - {ex.Message}"); }
 
         // Fallback: create a simple shield icon programmatically
         var bmp = new Bitmap(32, 32);

--- a/src/WinSentinel.App/Views/DashboardPage.xaml.cs
+++ b/src/WinSentinel.App/Views/DashboardPage.xaml.cs
@@ -221,7 +221,7 @@ public partial class DashboardPage : Page
                     var color = (Color)ColorConverter.ConvertFromString(SecurityScorer.GetScoreColor(report.SecurityScore));
                     ScoreRing.Stroke = new SolidColorBrush(color);
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] DashboardPage.xaml: {ex.GetType().Name} - {ex.Message}"); }
 
                 // Add to timeline
                 _viewModel.TimelineEntries.Add(new TimelineEntry
@@ -280,7 +280,7 @@ public partial class DashboardPage : Page
                     trend = _historyService.GetTrend(30);
                     if (trend.TotalScans == 0) trend = null;
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] DashboardPage.xaml: {ex.GetType().Name} - {ex.Message}"); }
 
                 // We need a report to export — run a quick audit if none available
                 var engine = new AuditEngine();
@@ -305,7 +305,7 @@ public partial class DashboardPage : Page
                             UseShellExecute = true
                         });
                     }
-                    catch { }
+                    catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] DashboardPage.xaml: {ex.GetType().Name} - {ex.Message}"); }
                 }
             }
             catch (Exception ex)

--- a/src/WinSentinel.Core/Audits/AppSecurityAudit.cs
+++ b/src/WinSentinel.Core/Audits/AppSecurityAudit.cs
@@ -582,7 +582,7 @@ public class AppSecurityAudit : IAuditModule
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AppSecurityAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Also check HKCU policy
         if (!autoUpdateDisabled)
@@ -596,7 +596,7 @@ public class AppSecurityAudit : IAuditModule
                     // This is more about content delivery than security updates, but worth noting
                 }
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AppSecurityAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         if (autoUpdateDisabled)

--- a/src/WinSentinel.Core/Audits/BackupAudit.cs
+++ b/src/WinSentinel.Core/Audits/BackupAudit.cs
@@ -146,7 +146,7 @@ public class BackupAudit : IAuditModule
                 state.VssStartType = parts[1].Trim();
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Shadow copies
         try
@@ -169,7 +169,7 @@ public class BackupAudit : IAuditModule
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // System Restore
         try
@@ -194,7 +194,7 @@ public class BackupAudit : IAuditModule
                 @"try {
                     Get-ComputerRestorePoint -ErrorAction Stop |
                     ForEach-Object { '{0}|{1}|{2}|{3}' -f $_.SequenceNumber, $_.Description, $_.CreationTime, $_.RestorePointType }
-                } catch { }", ct);
+                } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }", ct);
             foreach (var line in rpOutput.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
                 var p = line.Split('|');
@@ -210,7 +210,7 @@ public class BackupAudit : IAuditModule
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // File History
         try
@@ -224,7 +224,7 @@ public class BackupAudit : IAuditModule
                 } else { 'DISABLED' }", ct);
             state.FileHistoryEnabled = fh.Trim() == "ENABLED";
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Windows Backup
         try
@@ -242,7 +242,7 @@ public class BackupAudit : IAuditModule
             if (wbParts.Length > 1 && DateTimeOffset.TryParse(wbParts[1].Trim(), out var wbDt))
                 state.WindowsBackupLastRun = wbDt;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Recovery partition
         try
@@ -251,7 +251,7 @@ public class BackupAudit : IAuditModule
                 @"Get-Partition | Where-Object { $_.Type -eq 'Recovery' } | Measure-Object | Select-Object -ExpandProperty Count", ct);
             state.RecoveryPartitionExists = int.TryParse(rec.Trim(), out var cnt) && cnt > 0;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // BitLocker
         try
@@ -263,7 +263,7 @@ public class BackupAudit : IAuditModule
                 } catch { 'OFF' }", ct);
             state.BitLockerEnabled = bl.Trim() == "ON";
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Controlled folder access
         try
@@ -274,7 +274,7 @@ public class BackupAudit : IAuditModule
                 } catch { '0' }", ct);
             state.ControlledFolderAccessEnabled = cfa.Trim() == "1" || cfa.Trim().Equals("Enabled", StringComparison.OrdinalIgnoreCase);
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BackupAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         return state;
     }

--- a/src/WinSentinel.Core/Audits/BrowserAudit.cs
+++ b/src/WinSentinel.Core/Audits/BrowserAudit.cs
@@ -166,7 +166,7 @@ public class BrowserAudit : IAuditModule
                 using var key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Edge\BLBeacon");
                 version = key?.GetValue("version")?.ToString();
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         if (version == null)
@@ -215,7 +215,7 @@ public class BrowserAudit : IAuditModule
             using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Mozilla\Mozilla Firefox");
             version = key?.GetValue("CurrentVersion")?.ToString();
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         if (version == null)
         {
@@ -224,7 +224,7 @@ public class BrowserAudit : IAuditModule
                 using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\Mozilla\Mozilla Firefox");
                 version = key?.GetValue("CurrentVersion")?.ToString();
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         if (version == null)
@@ -386,7 +386,7 @@ public class BrowserAudit : IAuditModule
                     return name;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         return null;
     }
@@ -440,7 +440,7 @@ public class BrowserAudit : IAuditModule
                 }
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         return found;
     }
@@ -465,7 +465,7 @@ public class BrowserAudit : IAuditModule
             if (chromeUpdate != null && Convert.ToInt32(chromeUpdate) == 0)
                 chromeUpdateDisabled = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         if (chromeUpdateDisabled)
         {
@@ -486,7 +486,7 @@ public class BrowserAudit : IAuditModule
             if (updateDefault != null && Convert.ToInt32(updateDefault) == 0)
                 edgeUpdateDisabled = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         if (edgeUpdateDisabled)
         {
@@ -528,7 +528,7 @@ public class BrowserAudit : IAuditModule
             if (safeBrowsingEnabled != null && Convert.ToInt32(safeBrowsingEnabled) == 0)
                 chromeSafeBrowsingDisabled = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         if (chromeSafeBrowsingDisabled)
         {
@@ -549,7 +549,7 @@ public class BrowserAudit : IAuditModule
             if (smartScreen != null && Convert.ToInt32(smartScreen) == 0)
                 edgeSmartScreenDisabled = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Windows SmartScreen (system-wide)
         bool windowsSmartScreenDisabled = false;
@@ -561,7 +561,7 @@ public class BrowserAudit : IAuditModule
             if (smartScreen?.Equals("Off", StringComparison.OrdinalIgnoreCase) == true)
                 windowsSmartScreenDisabled = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         if (edgeSmartScreenDisabled)
         {
@@ -613,7 +613,7 @@ public class BrowserAudit : IAuditModule
                 // An empty Login Data SQLite DB is ~40KB. If it's larger, it likely has entries.
                 chromeSavedPasswords = fileInfo.Length > 45000;
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         // Edge Login Data
@@ -628,7 +628,7 @@ public class BrowserAudit : IAuditModule
                 var fileInfo = new FileInfo(edgeLoginData);
                 edgeSavedPasswords = fileInfo.Length > 45000;
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         if (chromeSavedPasswords || edgeSavedPasswords)
@@ -672,7 +672,7 @@ public class BrowserAudit : IAuditModule
             if (defaultPopups != null && Convert.ToInt32(defaultPopups) == 1)
                 chromePopupsAllowed = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Edge popup policy
         bool edgePopupsAllowed = false;
@@ -683,7 +683,7 @@ public class BrowserAudit : IAuditModule
             if (defaultPopups != null && Convert.ToInt32(defaultPopups) == 1)
                 edgePopupsAllowed = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         if (chromePopupsAllowed)
         {
@@ -729,7 +729,7 @@ public class BrowserAudit : IAuditModule
             if (dnt != null && Convert.ToInt32(dnt) == 1)
                 edgeDntEnabled = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Chrome doesn't have a direct registry policy for DNT — it's a user setting.
         // We can check if tracking prevention is enforced via policy on Edge.
@@ -742,7 +742,7 @@ public class BrowserAudit : IAuditModule
             if (trackingLevel != null && Convert.ToInt32(trackingLevel) >= 2)
                 edgeTrackingPrevention = true;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         if (!edgeDntEnabled && !edgeTrackingPrevention)
         {
@@ -786,7 +786,7 @@ public class BrowserAudit : IAuditModule
                     Category));
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Check if Chrome password manager is disabled via policy (good if using external manager)
         try
@@ -801,7 +801,7 @@ public class BrowserAudit : IAuditModule
                     Category));
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Check Edge password manager policy
         try
@@ -816,7 +816,7 @@ public class BrowserAudit : IAuditModule
                     Category));
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Check if Chrome site isolation is enforced
         try
@@ -831,7 +831,7 @@ public class BrowserAudit : IAuditModule
                     Category));
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Check if download restrictions are set
         try
@@ -847,7 +847,7 @@ public class BrowserAudit : IAuditModule
                     Category));
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
     }
 
     #endregion
@@ -863,7 +863,7 @@ public class BrowserAudit : IAuditModule
             var version = key?.GetValue(valueName)?.ToString();
             if (!string.IsNullOrEmpty(version)) return version;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
@@ -871,7 +871,7 @@ public class BrowserAudit : IAuditModule
             var version = key?.GetValue(fallbackValueName)?.ToString();
             if (!string.IsNullOrEmpty(version)) return version;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         // Try HKCU
         try
@@ -880,7 +880,7 @@ public class BrowserAudit : IAuditModule
             var version = key?.GetValue(valueName)?.ToString();
             if (!string.IsNullOrEmpty(version)) return version;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BrowserAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         return null;
     }

--- a/src/WinSentinel.Core/Audits/DriverAudit.cs
+++ b/src/WinSentinel.Core/Audits/DriverAudit.cs
@@ -205,7 +205,7 @@ public class DriverAudit : IAuditModule
                 state.TestSigningEnabled = bcdedit.Contains("testsigning") &&
                                            bcdedit.Contains("Yes", StringComparison.OrdinalIgnoreCase);
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] DriverAudit: {ex.GetType().Name} - {ex.Message}"); }
 
             // Check Secure Boot
             try
@@ -214,7 +214,7 @@ public class DriverAudit : IAuditModule
                     "Confirm-SecureBootUEFI -ErrorAction SilentlyContinue", ct);
                 state.SecureBootEnabled = secBoot.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] DriverAudit: {ex.GetType().Name} - {ex.Message}"); }
 
             // Check HVCI
             try
@@ -223,7 +223,7 @@ public class DriverAudit : IAuditModule
                     @"(Get-CimInstance -ClassName Win32_DeviceGuard -Namespace root\Microsoft\Windows\DeviceGuard -ErrorAction SilentlyContinue).SecurityServicesRunning -contains 2", ct);
                 state.HvciEnabled = hvci.Trim().Equals("True", StringComparison.OrdinalIgnoreCase);
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] DriverAudit: {ex.GetType().Name} - {ex.Message}"); }
 
             // Check driver block list
             try
@@ -232,7 +232,7 @@ public class DriverAudit : IAuditModule
                     @"$p = 'C:\Windows\System32\CodeIntegrity\driversipolicy.p7b'; if (Test-Path $p) { (Get-Item $p).LastWriteTime.ToString('yyyy-MM-dd') } else { 'not found' }", ct);
                 state.DriverBlockListVersion = blockList.Trim();
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] DriverAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
         catch { /* best effort collection */ }
 

--- a/src/WinSentinel.Core/Audits/EncryptionAudit.cs
+++ b/src/WinSentinel.Core/Audits/EncryptionAudit.cs
@@ -375,7 +375,7 @@ public class EncryptionAudit : IAuditModule
                     RegistryHive.LocalMachine, efsRegPath, "Start", -1);
                 efsServiceExists = startValue >= 0;
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EncryptionAudit: {ex.GetType().Name} - {ex.Message}"); }
 
             // Check for EFS certificates in user's certificate store
             int efsCertCount = 0;
@@ -402,7 +402,7 @@ public class EncryptionAudit : IAuditModule
                     }
                 }
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EncryptionAudit: {ex.GetType().Name} - {ex.Message}"); }
 
             // Check EFS disable policy
             var efsDisabled = RegistryHelper.GetValue<int>(
@@ -500,7 +500,7 @@ public class EncryptionAudit : IAuditModule
                                 issues.Add($"WEAK KEY: {GetCertDisplayName(cert)} (RSA {rsa.KeySize}-bit)");
                             }
                         }
-                        catch { }
+                        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EncryptionAudit: {ex.GetType().Name} - {ex.Message}"); }
                     }
 
                     // Check weak signature algorithm
@@ -908,7 +908,7 @@ public class EncryptionAudit : IAuditModule
                         cgStatus = psOutput.Contains("1") ? "Running" : "Not running";
                     }
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EncryptionAudit: {ex.GetType().Name} - {ex.Message}"); }
             }
 
             bool isRunning = cgStatus == "Running";
@@ -985,7 +985,7 @@ public class EncryptionAudit : IAuditModule
                     "(Get-WmiObject Win32_ComputerSystem).PartOfDomain", ct);
                 isDomainJoined = domainOutput.Contains("True", StringComparison.OrdinalIgnoreCase);
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EncryptionAudit: {ex.GetType().Name} - {ex.Message}"); }
 
             // Check if DPAPI is backed by TPM or domain controller
             var protectPath = @"SOFTWARE\Microsoft\Cryptography\Protect\Providers";

--- a/src/WinSentinel.Core/Audits/EventLogAudit.cs
+++ b/src/WinSentinel.Core/Audits/EventLogAudit.cs
@@ -266,7 +266,7 @@ public class EventLogAudit : IAuditModule
                         }
                     }
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EventLogAudit: {ex.GetType().Name} - {ex.Message}"); }
             }
 
             if (count == 0)
@@ -359,7 +359,7 @@ public class EventLogAudit : IAuditModule
                         }
                     }
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EventLogAudit: {ex.GetType().Name} - {ex.Message}"); }
             }
 
             int total = event4672Count + event4673Count;
@@ -667,7 +667,7 @@ public class EventLogAudit : IAuditModule
                             suspiciousCommands.Add($"• [{evt.TimeCreated:MM-dd HH:mm}] {snippet}");
                     }
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EventLogAudit: {ex.GetType().Name} - {ex.Message}"); }
             }
 
             if (suspiciousCount == 0 && events.Count == 0)
@@ -780,7 +780,7 @@ public class EventLogAudit : IAuditModule
                             threatNames.Add(threatName);
                     }
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EventLogAudit: {ex.GetType().Name} - {ex.Message}"); }
             }
 
             if (detections == 0)
@@ -888,7 +888,7 @@ public class EventLogAudit : IAuditModule
                             samples.Add($"• [{evt.TimeCreated:HH:mm}] {source} (ID {evt.Id}): {shortDesc}");
                         }
                     }
-                    catch { }
+                    catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EventLogAudit: {ex.GetType().Name} - {ex.Message}"); }
                 }
 
                 var topSources = sources.OrderByDescending(kv => kv.Value).Take(5)
@@ -987,7 +987,7 @@ public class EventLogAudit : IAuditModule
                         }
                     }
                 }
-                catch { }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] EventLogAudit: {ex.GetType().Name} - {ex.Message}"); }
             }
 
             long maxSizeBytes = logSizeBytes > 0 ? logSizeBytes : 20L * 1024 * 1024; // Default is usually 20 MB

--- a/src/WinSentinel.Core/Audits/GroupPolicyAudit.cs
+++ b/src/WinSentinel.Core/Audits/GroupPolicyAudit.cs
@@ -111,7 +111,7 @@ public class GroupPolicyAudit : IAuditModule
                 state.VbsEnabled = vbsVal >= 1;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] GroupPolicyAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         state.AuditProcessCommandLine = ReadRegistryDword(
             @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit",
@@ -124,7 +124,7 @@ public class GroupPolicyAudit : IAuditModule
                 "Select-Object -Skip 1 | ConvertFrom-Csv | Select-Object -ExpandProperty 'Inclusion Setting'", ct);
             state.AuditProcessCreation = ParseAuditSetting(auditOutput.Trim());
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] GroupPolicyAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
@@ -133,7 +133,7 @@ public class GroupPolicyAudit : IAuditModule
                 "Select-Object -Skip 1 | ConvertFrom-Csv | Select-Object -ExpandProperty 'Inclusion Setting'", ct);
             state.AuditLogonEvents = ParseAuditSetting(logonOutput.Trim());
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] GroupPolicyAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
@@ -142,7 +142,7 @@ public class GroupPolicyAudit : IAuditModule
                 "Select-Object -Skip 1 | ConvertFrom-Csv | Select-Object -ExpandProperty 'Inclusion Setting'", ct);
             state.AuditPrivilegeUse = ParseAuditSetting(privOutput.Trim());
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] GroupPolicyAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         state.RestrictedAdminMode = ReadRegistryDword(
             @"HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa", "DisableRestrictedAdmin");
@@ -177,7 +177,7 @@ public class GroupPolicyAudit : IAuditModule
                     state.AppLockerExeRuleCount = exeCount;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] GroupPolicyAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         state.SrpDefaultLevel = ReadRegistryDword(
             @"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Safer\CodeIdentifiers", "DefaultLevel");
@@ -549,7 +549,7 @@ public class GroupPolicyAudit : IAuditModule
                 if (int.TryParse(val, out var n)) return n;
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] GroupPolicyAudit: {ex.GetType().Name} - {ex.Message}"); }
         return null;
     }
 

--- a/src/WinSentinel.Core/Audits/ScheduledTaskAudit.cs
+++ b/src/WinSentinel.Core/Audits/ScheduledTaskAudit.cs
@@ -195,7 +195,7 @@ public class ScheduledTaskAudit : IAuditModule
                     state.TotalTaskCount = psOutput.Split("TaskName").Length - 1;
                 }
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ScheduledTaskAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         return state;

--- a/src/WinSentinel.Core/Audits/ServiceAudit.cs
+++ b/src/WinSentinel.Core/Audits/ServiceAudit.cs
@@ -185,7 +185,7 @@ public class ServiceAudit : IAuditModule
                     state.TotalServiceCount = scOutput.Split("SERVICE_NAME").Length - 1;
                 }
             }
-            catch { }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ServiceAudit: {ex.GetType().Name} - {ex.Message}"); }
         }
 
         return state;
@@ -218,7 +218,7 @@ public class ServiceAudit : IAuditModule
                     entries.Add(entry);
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ServiceAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         return entries;
     }

--- a/src/WinSentinel.Core/Audits/UpdateAudit.cs
+++ b/src/WinSentinel.Core/Audits/UpdateAudit.cs
@@ -76,7 +76,7 @@ public class UpdateAudit : AuditModuleBase
                 $history = $searcher.QueryHistory(0, 20)
                 $failed = @($history | Where-Object { $_.ResultCode -eq 4 -or $_.ResultCode -eq 5 }).Count
                 $indicators += $failed
-            } catch { }
+            } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] UpdateAudit: {ex.GetType().Name} - {ex.Message}"); }
             $indicators", ct);
 
         if (int.TryParse(output.Trim(), out int pendingCount))

--- a/src/WinSentinel.Core/Audits/VirtualizationAudit.cs
+++ b/src/WinSentinel.Core/Audits/VirtualizationAudit.cs
@@ -636,14 +636,14 @@ public class VirtualizationAudit : IAuditModule
                 Microsoft.Win32.RegistryHive.LocalMachine,
                 @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization", "Enabled") == 1;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] VirtualizationAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
             state.WslInstalled = File.Exists(
                 Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "wsl.exe"));
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] VirtualizationAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
@@ -652,7 +652,7 @@ public class VirtualizationAudit : IAuditModule
                 @"SYSTEM\CurrentControlSet\Control\DeviceGuard", "EnableVirtualizationBasedSecurity");
             state.VbsRunning = vbsStatus == 1;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] VirtualizationAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
@@ -662,7 +662,7 @@ public class VirtualizationAudit : IAuditModule
             state.CredentialGuardEnabled = lsaCfg is 1 or 2;
             state.CredentialGuardUefiLock = lsaCfg == 2;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] VirtualizationAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
@@ -673,7 +673,7 @@ public class VirtualizationAudit : IAuditModule
             state.HvciEnabled = hvci == 1;
             state.MemoryIntegrityEnabled = hvci == 1;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] VirtualizationAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
@@ -681,14 +681,14 @@ public class VirtualizationAudit : IAuditModule
                 Microsoft.Win32.RegistryHive.LocalMachine,
                 @"SYSTEM\CurrentControlSet\Control\SecureBoot\State", "UEFISecureBootEnabled") == 1;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] VirtualizationAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         try
         {
             state.DockerRunning = System.Diagnostics.Process.GetProcessesByName("dockerd").Length > 0 ||
                                   System.Diagnostics.Process.GetProcessesByName("com.docker.service").Length > 0;
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] VirtualizationAudit: {ex.GetType().Name} - {ex.Message}"); }
 
         return state;
     }

--- a/src/WinSentinel.Core/Helpers/RegistryHelper.cs
+++ b/src/WinSentinel.Core/Helpers/RegistryHelper.cs
@@ -94,7 +94,7 @@ public static class RegistryHelper
                 result[name] = key.GetValue(name);
             }
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] RegistryHelper: {ex.GetType().Name} - {ex.Message}"); }
         return result;
     }
 }

--- a/src/WinSentinel.Core/Services/IpcClient.cs
+++ b/src/WinSentinel.Core/Services/IpcClient.cs
@@ -239,9 +239,9 @@ public class IpcClient : IDisposable
                 HandleEvent(response);
             }
         }
-        catch (OperationCanceledException) { }
-        catch (IOException) { }
-        catch (Exception) { }
+        catch (OperationCanceledException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] IpcClient: {ex.GetType().Name} - {ex.Message}"); }
+        catch (IOException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] IpcClient: {ex.GetType().Name} - {ex.Message}"); }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] IpcClient: {ex.GetType().Name} - {ex.Message}"); }
         finally
         {
             Disconnected?.Invoke();
@@ -295,7 +295,7 @@ public class IpcClient : IDisposable
             _eventLoop?.Wait(TimeSpan.FromSeconds(2));
         }
         catch (AggregateException) { /* Swallow cancellation/IO exceptions */ }
-        catch (ObjectDisposedException) { }
+        catch (ObjectDisposedException ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] IpcClient: {ex.GetType().Name} - {ex.Message}"); }
 
         Cleanup();
         _sendLock.Dispose();

--- a/tests/WinSentinel.Tests/Agent/AgentBrainTests.cs
+++ b/tests/WinSentinel.Tests/Agent/AgentBrainTests.cs
@@ -16,7 +16,7 @@ public class AgentBrainTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_tempDir, true); } catch { }
+        try { Directory.Delete(_tempDir, true); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AgentBrainTests: {ex.GetType().Name} - {ex.Message}"); }
     }
 
     private (AgentBrain brain, ThreatLog log, ResponsePolicy policy, AgentJournal journal) CreateBrain(

--- a/tests/WinSentinel.Tests/Agent/AgentJournalTests.cs
+++ b/tests/WinSentinel.Tests/Agent/AgentJournalTests.cs
@@ -16,7 +16,7 @@ public class AgentJournalTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_tempDir, true); } catch { }
+        try { Directory.Delete(_tempDir, true); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AgentJournalTests: {ex.GetType().Name} - {ex.Message}"); }
     }
 
     private AgentJournal CreateJournal()

--- a/tests/WinSentinel.Tests/Agent/ChatHandlerTests.cs
+++ b/tests/WinSentinel.Tests/Agent/ChatHandlerTests.cs
@@ -52,7 +52,7 @@ public class ChatHandlerTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_tempDir, true); } catch { }
+        try { Directory.Delete(_tempDir, true); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] ChatHandlerTests: {ex.GetType().Name} - {ex.Message}"); }
     }
 
     // ══════════════════════════════════════════

--- a/tests/WinSentinel.Tests/Services/AuditEngineTests.cs
+++ b/tests/WinSentinel.Tests/Services/AuditEngineTests.cs
@@ -311,7 +311,7 @@ public class AuditEngineTests
         }
         finally
         {
-            try { File.Delete(tempPath); } catch { }
+            try { File.Delete(tempPath); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AuditEngineTests: {ex.GetType().Name} - {ex.Message}"); }
         }
     }
 

--- a/tests/WinSentinel.Tests/Services/AuditHistoryServiceTests.cs
+++ b/tests/WinSentinel.Tests/Services/AuditHistoryServiceTests.cs
@@ -19,7 +19,7 @@ public class AuditHistoryServiceTests : IDisposable
         _service.Dispose();
         if (File.Exists(_dbPath))
         {
-            try { File.Delete(_dbPath); } catch { }
+            try { File.Delete(_dbPath); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] AuditHistoryServiceTests: {ex.GetType().Name} - {ex.Message}"); }
         }
     }
 

--- a/tests/WinSentinel.Tests/Services/BaselineServiceTests.cs
+++ b/tests/WinSentinel.Tests/Services/BaselineServiceTests.cs
@@ -22,7 +22,7 @@ public class BaselineServiceTests : IDisposable
             if (Directory.Exists(_testDir))
                 Directory.Delete(_testDir, true);
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] BaselineServiceTests: {ex.GetType().Name} - {ex.Message}"); }
     }
 
     private static SecurityReport CreateTestReport(int score = 75, int criticals = 1, int warnings = 2)

--- a/tests/WinSentinel.Tests/Services/HtmlDashboardGeneratorTests.cs
+++ b/tests/WinSentinel.Tests/Services/HtmlDashboardGeneratorTests.cs
@@ -15,8 +15,8 @@ public class HtmlDashboardGeneratorTests : IDisposable
     {
         foreach (var f in _tempFiles)
         {
-            try { if (File.Exists(f)) File.Delete(f); } catch { }
-            try { var d = Path.GetDirectoryName(f); if (d != null && Directory.Exists(d) && !Directory.EnumerateFileSystemEntries(d).Any()) Directory.Delete(d); } catch { }
+            try { if (File.Exists(f)) File.Delete(f); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] HtmlDashboardGeneratorTests: {ex.GetType().Name} - {ex.Message}"); }
+            try { var d = Path.GetDirectoryName(f); if (d != null && Directory.Exists(d) && !Directory.EnumerateFileSystemEntries(d).Any()) Directory.Delete(d); } catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] HtmlDashboardGeneratorTests: {ex.GetType().Name} - {ex.Message}"); }
         }
     }
 

--- a/tests/WinSentinel.Tests/Services/IgnoreRuleServiceTests.cs
+++ b/tests/WinSentinel.Tests/Services/IgnoreRuleServiceTests.cs
@@ -24,7 +24,7 @@ public class IgnoreRuleServiceTests : IDisposable
             if (Directory.Exists(_testDir))
                 Directory.Delete(_testDir, true);
         }
-        catch { }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"[WinSentinel] IgnoreRuleServiceTests: {ex.GetType().Name} - {ex.Message}"); }
     }
 
     private static SecurityReport CreateTestReport()


### PR DESCRIPTION
## Summary

Replaces all 102 empty `catch` blocks across 32 files with `System.Diagnostics.Debug.WriteLine` logging that includes the class name and exception details.

## Problem

For a security auditing tool, silently swallowing exceptions is dangerous:
- **Silent audit failures:** Failed security checks return incomplete results with no indication
- **Monitoring blind spots:** Agent modules drop events on error — exactly when something suspicious might be happening
- **Debugging nightmare:** No log trail when users report missing findings

## Fix

Every empty `catch { }` now logs with `[WinSentinel] ClassName: ExType - Message` format via `System.Diagnostics.Debug.WriteLine`.

### Top offenders fixed:
- BrowserAudit.cs: 24 catches
- BackupAudit.cs: 9 catches
- VirtualizationAudit.cs: 7 catches
- GroupPolicyAudit.cs: 6 catches
- EventLogAudit.cs: 6 catches
- NetworkMonitorModule.cs: 6 catches
- + 26 more files: 44 catches

Fixes #51
