### PR TITLE
feat: SLA Tracker — remediation deadline tracking with compliance reporting

### DIFF
--- a/src/WinSentinel.Core/Services/SlaTracker.cs
+++ b/src/WinSentinel.Core/Services/SlaTracker.cs
@@ -1,0 +1,732 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+/// <summary>
+/// Tracks remediation SLA compliance for security findings.
+/// <para>
+/// Each finding severity has a configurable remediation deadline:
+/// Critical findings must be remediated within hours, warnings within days.
+/// The tracker monitors which findings are on track, approaching their
+/// deadline, or overdue, and computes SLA compliance metrics.
+/// </para>
+/// <para>
+/// Use cases:
+/// <list type="bullet">
+///   <item>Track remediation progress against organizational SLA policies</item>
+///   <item>Flag overdue findings before compliance audits</item>
+///   <item>Generate SLA compliance reports for management</item>
+///   <item>Prioritize remediation work by deadline urgency</item>
+///   <item>Measure mean time to remediate (MTTR) by severity</item>
+/// </list>
+/// </para>
+/// </summary>
+public class SlaTracker
+{
+    // ── Configuration ────────────────────────────────────────────
+
+    /// <summary>SLA policy defining remediation deadlines per severity.</summary>
+    public class SlaPolicy
+    {
+        /// <summary>Maximum time to remediate Critical findings.</summary>
+        public TimeSpan CriticalDeadline { get; set; } = TimeSpan.FromHours(24);
+
+        /// <summary>Maximum time to remediate Warning findings.</summary>
+        public TimeSpan WarningDeadline { get; set; } = TimeSpan.FromDays(7);
+
+        /// <summary>Maximum time to remediate Info findings.</summary>
+        public TimeSpan InfoDeadline { get; set; } = TimeSpan.FromDays(30);
+
+        /// <summary>
+        /// Fraction of the deadline at which a finding is considered "approaching"
+        /// (e.g., 0.75 means the last 25% of the window triggers a warning).
+        /// </summary>
+        public double ApproachingThreshold { get; set; } = 0.75;
+
+        /// <summary>Name of this policy (e.g., "SOC2", "Internal", "HIPAA").</summary>
+        public string Name { get; set; } = "Default";
+
+        /// <summary>Get the deadline for a given severity.</summary>
+        public TimeSpan GetDeadline(Severity severity) => severity switch
+        {
+            Severity.Critical => CriticalDeadline,
+            Severity.Warning => WarningDeadline,
+            Severity.Info => InfoDeadline,
+            _ => TimeSpan.MaxValue // Pass findings have no SLA
+        };
+
+        /// <summary>Standard enterprise policy: Critical 24h, Warning 7d, Info 30d.</summary>
+        public static SlaPolicy Enterprise => new()
+        {
+            Name = "Enterprise",
+            CriticalDeadline = TimeSpan.FromHours(24),
+            WarningDeadline = TimeSpan.FromDays(7),
+            InfoDeadline = TimeSpan.FromDays(30),
+        };
+
+        /// <summary>Strict compliance policy: Critical 4h, Warning 48h, Info 14d.</summary>
+        public static SlaPolicy Strict => new()
+        {
+            Name = "Strict",
+            CriticalDeadline = TimeSpan.FromHours(4),
+            WarningDeadline = TimeSpan.FromHours(48),
+            InfoDeadline = TimeSpan.FromDays(14),
+            ApproachingThreshold = 0.5,
+        };
+
+        /// <summary>Relaxed policy for low-risk environments: Critical 72h, Warning 30d, Info 90d.</summary>
+        public static SlaPolicy Relaxed => new()
+        {
+            Name = "Relaxed",
+            CriticalDeadline = TimeSpan.FromHours(72),
+            WarningDeadline = TimeSpan.FromDays(30),
+            InfoDeadline = TimeSpan.FromDays(90),
+        };
+    }
+
+    /// <summary>SLA status for a tracked finding.</summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum SlaStatus
+    {
+        /// <summary>Within the remediation window.</summary>
+        OnTrack,
+        /// <summary>Approaching the deadline (past the threshold).</summary>
+        Approaching,
+        /// <summary>Past the remediation deadline.</summary>
+        Overdue,
+        /// <summary>Finding has been resolved.</summary>
+        Resolved,
+        /// <summary>Finding severity has no SLA (Pass findings).</summary>
+        Exempt
+    }
+
+    // ── Tracked finding record ───────────────────────────────────
+
+    /// <summary>
+    /// A finding being tracked for SLA compliance.
+    /// </summary>
+    public class TrackedFinding
+    {
+        /// <summary>Unique identifier for this tracked finding.</summary>
+        public string Id { get; set; } = "";
+
+        /// <summary>The finding title.</summary>
+        public string Title { get; set; } = "";
+
+        /// <summary>Category/module that produced the finding.</summary>
+        public string Category { get; set; } = "";
+
+        /// <summary>Finding severity at time of detection.</summary>
+        public Severity Severity { get; set; }
+
+        /// <summary>When the finding was first detected.</summary>
+        public DateTimeOffset DetectedAt { get; set; }
+
+        /// <summary>The remediation deadline based on policy.</summary>
+        public DateTimeOffset Deadline { get; set; }
+
+        /// <summary>When the finding was resolved (null if still open).</summary>
+        public DateTimeOffset? ResolvedAt { get; set; }
+
+        /// <summary>Whether the finding is still open.</summary>
+        [JsonIgnore]
+        public bool IsOpen => ResolvedAt == null;
+
+        /// <summary>Time spent open (resolved or still ticking).</summary>
+        [JsonIgnore]
+        public TimeSpan TimeOpen => (ResolvedAt ?? DateTimeOffset.UtcNow) - DetectedAt;
+
+        /// <summary>Whether remediation met the SLA deadline.</summary>
+        [JsonIgnore]
+        public bool MetSla => ResolvedAt.HasValue && ResolvedAt.Value <= Deadline;
+
+        /// <summary>Optional notes about the resolution.</summary>
+        public string? ResolutionNotes { get; set; }
+    }
+
+    // ── SLA assessment result ────────────────────────────────────
+
+    /// <summary>SLA status assessment for a single finding.</summary>
+    public class FindingSlaAssessment
+    {
+        /// <summary>The tracked finding.</summary>
+        public required TrackedFinding Finding { get; init; }
+
+        /// <summary>Current SLA status.</summary>
+        public SlaStatus Status { get; init; }
+
+        /// <summary>Time remaining until deadline (negative if overdue).</summary>
+        public TimeSpan TimeRemaining { get; init; }
+
+        /// <summary>Fraction of the SLA window consumed (0.0 to 1.0+).</summary>
+        public double WindowConsumed { get; init; }
+
+        /// <summary>Human-readable urgency description.</summary>
+        public string UrgencyLabel => Status switch
+        {
+            SlaStatus.Overdue => $"OVERDUE by {FormatDuration(-TimeRemaining)}",
+            SlaStatus.Approaching => $"{FormatDuration(TimeRemaining)} remaining",
+            SlaStatus.OnTrack => $"{FormatDuration(TimeRemaining)} remaining",
+            SlaStatus.Resolved => Finding.MetSla ? "Resolved within SLA" : "Resolved AFTER SLA",
+            SlaStatus.Exempt => "No SLA",
+            _ => "Unknown"
+        };
+
+        private static string FormatDuration(TimeSpan ts)
+        {
+            if (ts.TotalDays >= 1)
+                return $"{ts.Days}d {ts.Hours}h";
+            if (ts.TotalHours >= 1)
+                return $"{ts.Hours}h {ts.Minutes}m";
+            return $"{ts.Minutes}m";
+        }
+    }
+
+    // ── SLA compliance report ────────────────────────────────────
+
+    /// <summary>Overall SLA compliance report.</summary>
+    public class SlaComplianceReport
+    {
+        /// <summary>Policy used for this report.</summary>
+        public string PolicyName { get; init; } = "";
+
+        /// <summary>Report generation timestamp.</summary>
+        public DateTimeOffset GeneratedAt { get; init; }
+
+        /// <summary>Total tracked findings.</summary>
+        public int TotalTracked { get; init; }
+
+        /// <summary>Currently open findings.</summary>
+        public int OpenCount { get; init; }
+
+        /// <summary>Resolved findings.</summary>
+        public int ResolvedCount { get; init; }
+
+        /// <summary>Findings currently overdue.</summary>
+        public int OverdueCount { get; init; }
+
+        /// <summary>Findings approaching their deadline.</summary>
+        public int ApproachingCount { get; init; }
+
+        /// <summary>Overall SLA compliance percentage (resolved within deadline / total resolved).</summary>
+        public double CompliancePercent { get; init; }
+
+        /// <summary>Per-severity compliance breakdown.</summary>
+        public Dictionary<Severity, SeverityCompliance> BySeverity { get; init; } = new();
+
+        /// <summary>Mean time to remediate (all resolved findings).</summary>
+        public TimeSpan? MeanTimeToRemediate { get; init; }
+
+        /// <summary>Per-severity MTTR.</summary>
+        public Dictionary<Severity, TimeSpan> MttrBySeverity { get; init; } = new();
+
+        /// <summary>Individual finding assessments, ordered by urgency.</summary>
+        public List<FindingSlaAssessment> Assessments { get; init; } = [];
+
+        /// <summary>Top overdue findings requiring immediate attention.</summary>
+        public List<FindingSlaAssessment> TopOverdue { get; init; } = [];
+
+        /// <summary>Findings approaching their deadline.</summary>
+        public List<FindingSlaAssessment> ApproachingDeadline { get; init; } = [];
+    }
+
+    /// <summary>Compliance stats for a single severity level.</summary>
+    public class SeverityCompliance
+    {
+        /// <summary>Total findings at this severity.</summary>
+        public int Total { get; init; }
+
+        /// <summary>Resolved within SLA.</summary>
+        public int MetSla { get; init; }
+
+        /// <summary>Resolved after SLA or still overdue.</summary>
+        public int MissedSla { get; init; }
+
+        /// <summary>Still open and on track.</summary>
+        public int OnTrack { get; init; }
+
+        /// <summary>Compliance percentage for this severity.</summary>
+        public double CompliancePercent { get; init; }
+
+        /// <summary>Mean time to remediate at this severity.</summary>
+        public TimeSpan? Mttr { get; init; }
+    }
+
+    // ── State ────────────────────────────────────────────────────
+
+    private readonly List<TrackedFinding> _findings = new();
+    private readonly SlaPolicy _policy;
+    private int _nextId;
+
+    /// <summary>All tracked findings.</summary>
+    public IReadOnlyList<TrackedFinding> Findings => _findings;
+
+    /// <summary>The active SLA policy.</summary>
+    public SlaPolicy Policy => _policy;
+
+    /// <summary>
+    /// Create a new SLA tracker with the specified policy.
+    /// </summary>
+    /// <param name="policy">SLA policy to enforce. Uses Enterprise defaults if null.</param>
+    public SlaTracker(SlaPolicy? policy = null)
+    {
+        _policy = policy ?? SlaPolicy.Enterprise;
+    }
+
+    // ── Tracking operations ──────────────────────────────────────
+
+    /// <summary>
+    /// Begin tracking a finding for SLA compliance.
+    /// </summary>
+    /// <param name="finding">The security finding to track.</param>
+    /// <param name="detectedAt">When the finding was detected. Defaults to now.</param>
+    /// <returns>The tracked finding record with deadline assigned.</returns>
+    /// <exception cref="ArgumentNullException">If finding is null.</exception>
+    public TrackedFinding Track(Finding finding, DateTimeOffset? detectedAt = null)
+    {
+        ArgumentNullException.ThrowIfNull(finding);
+
+        var detected = detectedAt ?? DateTimeOffset.UtcNow;
+        var deadline = _policy.GetDeadline(finding.Severity);
+
+        var tracked = new TrackedFinding
+        {
+            Id = $"SLA-{++_nextId:D4}",
+            Title = finding.Title,
+            Category = finding.Category,
+            Severity = finding.Severity,
+            DetectedAt = detected,
+            Deadline = deadline == TimeSpan.MaxValue
+                ? DateTimeOffset.MaxValue
+                : detected + deadline,
+        };
+
+        _findings.Add(tracked);
+        return tracked;
+    }
+
+    /// <summary>
+    /// Track all actionable findings from a security report.
+    /// Only Critical, Warning, and Info findings are tracked (Pass is exempt).
+    /// </summary>
+    /// <param name="report">The security report to import.</param>
+    /// <param name="detectedAt">Detection timestamp. Defaults to report generation time.</param>
+    /// <returns>Number of findings now being tracked.</returns>
+    public int TrackReport(SecurityReport report, DateTimeOffset? detectedAt = null)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        var detected = detectedAt ?? report.GeneratedAt;
+        int count = 0;
+
+        foreach (var result in report.Results)
+        {
+            foreach (var finding in result.Findings)
+            {
+                if (finding.Severity == Severity.Pass)
+                    continue;
+
+                Track(finding, detected);
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Mark a tracked finding as resolved.
+    /// </summary>
+    /// <param name="findingId">The tracked finding ID (e.g., "SLA-0001").</param>
+    /// <param name="resolvedAt">Resolution timestamp. Defaults to now.</param>
+    /// <param name="notes">Optional resolution notes.</param>
+    /// <returns>The updated tracked finding.</returns>
+    /// <exception cref="ArgumentException">If the finding ID is not found.</exception>
+    /// <exception cref="InvalidOperationException">If the finding is already resolved.</exception>
+    public TrackedFinding Resolve(string findingId, DateTimeOffset? resolvedAt = null, string? notes = null)
+    {
+        var tracked = _findings.FirstOrDefault(f =>
+            f.Id.Equals(findingId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new ArgumentException($"Finding '{findingId}' not found");
+
+        if (!tracked.IsOpen)
+            throw new InvalidOperationException($"Finding '{findingId}' is already resolved");
+
+        tracked.ResolvedAt = resolvedAt ?? DateTimeOffset.UtcNow;
+        tracked.ResolutionNotes = notes;
+        return tracked;
+    }
+
+    /// <summary>
+    /// Resolve findings by title match (case-insensitive).
+    /// Useful when a remediation fixes a known finding across modules.
+    /// </summary>
+    /// <param name="titlePattern">Substring to match against finding titles.</param>
+    /// <param name="resolvedAt">Resolution timestamp. Defaults to now.</param>
+    /// <returns>Number of findings resolved.</returns>
+    public int ResolveByTitle(string titlePattern, DateTimeOffset? resolvedAt = null)
+    {
+        var resolved = resolvedAt ?? DateTimeOffset.UtcNow;
+        int count = 0;
+
+        foreach (var f in _findings.Where(f => f.IsOpen &&
+            f.Title.Contains(titlePattern, StringComparison.OrdinalIgnoreCase)))
+        {
+            f.ResolvedAt = resolved;
+            count++;
+        }
+
+        return count;
+    }
+
+    // ── Assessment ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Assess the SLA status of a single tracked finding.
+    /// </summary>
+    /// <param name="finding">The tracked finding.</param>
+    /// <param name="asOf">Point in time for assessment. Defaults to now.</param>
+    /// <returns>SLA assessment with status, time remaining, and urgency.</returns>
+    public FindingSlaAssessment Assess(TrackedFinding finding, DateTimeOffset? asOf = null)
+    {
+        ArgumentNullException.ThrowIfNull(finding);
+
+        var now = asOf ?? DateTimeOffset.UtcNow;
+
+        // Exempt (Pass findings)
+        if (finding.Severity == Severity.Pass || finding.Deadline == DateTimeOffset.MaxValue)
+        {
+            return new FindingSlaAssessment
+            {
+                Finding = finding,
+                Status = SlaStatus.Exempt,
+                TimeRemaining = TimeSpan.MaxValue,
+                WindowConsumed = 0,
+            };
+        }
+
+        // Resolved
+        if (!finding.IsOpen)
+        {
+            return new FindingSlaAssessment
+            {
+                Finding = finding,
+                Status = SlaStatus.Resolved,
+                TimeRemaining = finding.Deadline - finding.ResolvedAt!.Value,
+                WindowConsumed = finding.TimeOpen / (finding.Deadline - finding.DetectedAt),
+            };
+        }
+
+        var remaining = finding.Deadline - now;
+        var totalWindow = finding.Deadline - finding.DetectedAt;
+        var consumed = totalWindow.TotalSeconds > 0
+            ? (now - finding.DetectedAt).TotalSeconds / totalWindow.TotalSeconds
+            : 1.0;
+
+        SlaStatus status;
+        if (remaining <= TimeSpan.Zero)
+            status = SlaStatus.Overdue;
+        else if (consumed >= _policy.ApproachingThreshold)
+            status = SlaStatus.Approaching;
+        else
+            status = SlaStatus.OnTrack;
+
+        return new FindingSlaAssessment
+        {
+            Finding = finding,
+            Status = status,
+            TimeRemaining = remaining,
+            WindowConsumed = consumed,
+        };
+    }
+
+    /// <summary>
+    /// Generate a comprehensive SLA compliance report.
+    /// </summary>
+    /// <param name="asOf">Point in time for the report. Defaults to now.</param>
+    /// <returns>Full SLA compliance report with metrics and assessments.</returns>
+    public SlaComplianceReport GenerateReport(DateTimeOffset? asOf = null)
+    {
+        var now = asOf ?? DateTimeOffset.UtcNow;
+
+        var assessments = _findings
+            .Select(f => Assess(f, now))
+            .OrderBy(a => a.Status == SlaStatus.Overdue ? 0 :
+                          a.Status == SlaStatus.Approaching ? 1 :
+                          a.Status == SlaStatus.OnTrack ? 2 : 3)
+            .ThenBy(a => a.TimeRemaining)
+            .ToList();
+
+        var resolved = _findings.Where(f => !f.IsOpen).ToList();
+        var open = _findings.Where(f => f.IsOpen).ToList();
+
+        // Overall compliance: resolved within SLA / total resolved
+        var metSla = resolved.Count(f => f.MetSla);
+        var compliancePct = resolved.Count > 0
+            ? Math.Round(100.0 * metSla / resolved.Count, 1)
+            : 100.0;
+
+        // MTTR
+        TimeSpan? overallMttr = resolved.Count > 0
+            ? TimeSpan.FromSeconds(resolved.Average(f => f.TimeOpen.TotalSeconds))
+            : null;
+
+        // Per-severity breakdown
+        var severities = new[] { Severity.Critical, Severity.Warning, Severity.Info };
+        var bySeverity = new Dictionary<Severity, SeverityCompliance>();
+        var mttrBySeverity = new Dictionary<Severity, TimeSpan>();
+
+        foreach (var sev in severities)
+        {
+            var sevFindings = _findings.Where(f => f.Severity == sev).ToList();
+            var sevResolved = sevFindings.Where(f => !f.IsOpen).ToList();
+            var sevMetSla = sevResolved.Count(f => f.MetSla);
+            var sevOnTrack = assessments.Count(a =>
+                a.Finding.Severity == sev && a.Status == SlaStatus.OnTrack);
+
+            bySeverity[sev] = new SeverityCompliance
+            {
+                Total = sevFindings.Count,
+                MetSla = sevMetSla,
+                MissedSla = sevFindings.Count - sevMetSla - sevOnTrack,
+                OnTrack = sevOnTrack,
+                CompliancePercent = sevResolved.Count > 0
+                    ? Math.Round(100.0 * sevMetSla / sevResolved.Count, 1)
+                    : 100.0,
+                Mttr = sevResolved.Count > 0
+                    ? TimeSpan.FromSeconds(sevResolved.Average(f => f.TimeOpen.TotalSeconds))
+                    : null,
+            };
+
+            if (sevResolved.Count > 0)
+                mttrBySeverity[sev] = TimeSpan.FromSeconds(
+                    sevResolved.Average(f => f.TimeOpen.TotalSeconds));
+        }
+
+        var overdue = assessments.Where(a => a.Status == SlaStatus.Overdue).ToList();
+        var approaching = assessments.Where(a => a.Status == SlaStatus.Approaching).ToList();
+
+        return new SlaComplianceReport
+        {
+            PolicyName = _policy.Name,
+            GeneratedAt = now,
+            TotalTracked = _findings.Count,
+            OpenCount = open.Count,
+            ResolvedCount = resolved.Count,
+            OverdueCount = overdue.Count,
+            ApproachingCount = approaching.Count,
+            CompliancePercent = compliancePct,
+            BySeverity = bySeverity,
+            MeanTimeToRemediate = overallMttr,
+            MttrBySeverity = mttrBySeverity,
+            Assessments = assessments,
+            TopOverdue = overdue.Take(10).ToList(),
+            ApproachingDeadline = approaching.Take(10).ToList(),
+        };
+    }
+
+    // ── Query helpers ────────────────────────────────────────────
+
+    /// <summary>Get all open findings.</summary>
+    public IReadOnlyList<TrackedFinding> GetOpen() =>
+        _findings.Where(f => f.IsOpen).ToList();
+
+    /// <summary>Get all overdue findings.</summary>
+    public IReadOnlyList<TrackedFinding> GetOverdue(DateTimeOffset? asOf = null)
+    {
+        var now = asOf ?? DateTimeOffset.UtcNow;
+        return _findings
+            .Where(f => f.IsOpen && f.Deadline < now && f.Deadline != DateTimeOffset.MaxValue)
+            .OrderBy(f => f.Deadline)
+            .ToList();
+    }
+
+    /// <summary>Get findings approaching their deadline.</summary>
+    public IReadOnlyList<TrackedFinding> GetApproaching(DateTimeOffset? asOf = null)
+    {
+        var now = asOf ?? DateTimeOffset.UtcNow;
+        return _findings
+            .Where(f =>
+            {
+                if (!f.IsOpen || f.Deadline == DateTimeOffset.MaxValue) return false;
+                var total = (f.Deadline - f.DetectedAt).TotalSeconds;
+                if (total <= 0) return false;
+                var consumed = (now - f.DetectedAt).TotalSeconds / total;
+                return consumed >= _policy.ApproachingThreshold && f.Deadline > now;
+            })
+            .OrderBy(f => f.Deadline)
+            .ToList();
+    }
+
+    /// <summary>Get a tracked finding by its ID.</summary>
+    public TrackedFinding? GetById(string id) =>
+        _findings.FirstOrDefault(f => f.Id.Equals(id, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Get findings by category.</summary>
+    public IReadOnlyList<TrackedFinding> GetByCategory(string category) =>
+        _findings.Where(f => f.Category.Equals(category, StringComparison.OrdinalIgnoreCase)).ToList();
+
+    /// <summary>Get findings by severity.</summary>
+    public IReadOnlyList<TrackedFinding> GetBySeverity(Severity severity) =>
+        _findings.Where(f => f.Severity == severity).ToList();
+
+    // ── Serialization ────────────────────────────────────────────
+
+    /// <summary>
+    /// Export tracked findings to JSON for persistence.
+    /// </summary>
+    public string ExportJson()
+    {
+        var data = new
+        {
+            policy = new
+            {
+                _policy.Name,
+                CriticalHours = _policy.CriticalDeadline.TotalHours,
+                WarningDays = _policy.WarningDeadline.TotalDays,
+                InfoDays = _policy.InfoDeadline.TotalDays,
+                _policy.ApproachingThreshold,
+            },
+            findings = _findings,
+            exportedAt = DateTimeOffset.UtcNow,
+        };
+
+        return JsonSerializer.Serialize(data, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() },
+        });
+    }
+
+    /// <summary>
+    /// Import previously exported findings.
+    /// </summary>
+    /// <param name="json">JSON string from <see cref="ExportJson"/>.</param>
+    /// <returns>Number of findings imported.</returns>
+    public int ImportJson(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (!root.TryGetProperty("findings", out var findingsEl))
+            throw new ArgumentException("JSON must contain a 'findings' array");
+
+        int count = 0;
+        foreach (var el in findingsEl.EnumerateArray())
+        {
+            var tracked = new TrackedFinding
+            {
+                Id = el.GetProperty("Id").GetString() ?? $"SLA-{++_nextId:D4}",
+                Title = el.GetProperty("Title").GetString() ?? "",
+                Category = el.GetProperty("Category").GetString() ?? "",
+                Severity = Enum.Parse<Severity>(el.GetProperty("Severity").GetString() ?? "Info"),
+                DetectedAt = el.GetProperty("DetectedAt").GetDateTimeOffset(),
+                Deadline = el.GetProperty("Deadline").GetDateTimeOffset(),
+            };
+
+            if (el.TryGetProperty("ResolvedAt", out var resolvedEl) &&
+                resolvedEl.ValueKind != JsonValueKind.Null)
+            {
+                tracked.ResolvedAt = resolvedEl.GetDateTimeOffset();
+            }
+
+            if (el.TryGetProperty("ResolutionNotes", out var notesEl) &&
+                notesEl.ValueKind != JsonValueKind.Null)
+            {
+                tracked.ResolutionNotes = notesEl.GetString();
+            }
+
+            _findings.Add(tracked);
+
+            // Keep ID sequence consistent
+            if (tracked.Id.StartsWith("SLA-") &&
+                int.TryParse(tracked.Id[4..], out var num) && num > _nextId)
+            {
+                _nextId = num;
+            }
+
+            count++;
+        }
+
+        return count;
+    }
+
+    // ── Text report ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Generate a plain-text SLA compliance summary.
+    /// </summary>
+    public string GenerateTextReport(DateTimeOffset? asOf = null)
+    {
+        var report = GenerateReport(asOf);
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"═══ SLA Compliance Report ({report.PolicyName}) ═══");
+        sb.AppendLine($"Generated: {report.GeneratedAt:yyyy-MM-dd HH:mm:ss}");
+        sb.AppendLine();
+
+        // Overall stats
+        sb.AppendLine($"Total Tracked:    {report.TotalTracked}");
+        sb.AppendLine($"Open:             {report.OpenCount}");
+        sb.AppendLine($"Resolved:         {report.ResolvedCount}");
+        sb.AppendLine($"Overdue:          {report.OverdueCount}");
+        sb.AppendLine($"Approaching:      {report.ApproachingCount}");
+        sb.AppendLine($"SLA Compliance:   {report.CompliancePercent}%");
+
+        if (report.MeanTimeToRemediate.HasValue)
+            sb.AppendLine($"Mean TTR:         {FormatTimeSpan(report.MeanTimeToRemediate.Value)}");
+
+        sb.AppendLine();
+
+        // Per-severity breakdown
+        sb.AppendLine("── By Severity ──");
+        foreach (var (sev, comp) in report.BySeverity.OrderByDescending(kv => (int)kv.Key))
+        {
+            if (comp.Total == 0) continue;
+            var deadline = _policy.GetDeadline(sev);
+            sb.AppendLine($"  {sev,-10} ({FormatTimeSpan(deadline)} SLA):");
+            sb.AppendLine($"    Total: {comp.Total} | Met SLA: {comp.MetSla} | " +
+                          $"Missed: {comp.MissedSla} | On Track: {comp.OnTrack}");
+            sb.AppendLine($"    Compliance: {comp.CompliancePercent}%");
+            if (comp.Mttr.HasValue)
+                sb.AppendLine($"    MTTR: {FormatTimeSpan(comp.Mttr.Value)}");
+        }
+
+        // Overdue items
+        if (report.TopOverdue.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("── OVERDUE ──");
+            foreach (var a in report.TopOverdue)
+            {
+                sb.AppendLine($"  [{a.Finding.Severity}] {a.Finding.Title}");
+                sb.AppendLine($"    Category: {a.Finding.Category} | {a.UrgencyLabel}");
+            }
+        }
+
+        // Approaching deadline
+        if (report.ApproachingDeadline.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("── APPROACHING DEADLINE ──");
+            foreach (var a in report.ApproachingDeadline)
+            {
+                sb.AppendLine($"  [{a.Finding.Severity}] {a.Finding.Title}");
+                sb.AppendLine($"    Category: {a.Finding.Category} | {a.UrgencyLabel}");
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatTimeSpan(TimeSpan ts)
+    {
+        if (ts == TimeSpan.MaxValue) return "∞";
+        if (ts.TotalDays >= 1) return $"{ts.Days}d {ts.Hours}h";
+        if (ts.TotalHours >= 1) return $"{(int)ts.TotalHours}h {ts.Minutes}m";
+        return $"{(int)ts.TotalMinutes}m";
+    }
+}

--- a/tests/WinSentinel.Tests/SlaTrackerTests.cs
+++ b/tests/WinSentinel.Tests/SlaTrackerTests.cs
@@ -1,0 +1,622 @@
+using Xunit;
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests;
+
+public class SlaTrackerTests
+{
+    private static readonly DateTimeOffset _baseTime =
+        new(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static Finding MakeFinding(Severity severity, string title = "Test Finding",
+        string category = "TestModule") =>
+        new() { Title = title, Description = "desc", Severity = severity, Category = category };
+
+    // ── Policy presets ───────────────────────────────────────────
+
+    [Fact]
+    public void Enterprise_Policy_Has_Expected_Defaults()
+    {
+        var p = SlaTracker.SlaPolicy.Enterprise;
+        Assert.Equal(TimeSpan.FromHours(24), p.CriticalDeadline);
+        Assert.Equal(TimeSpan.FromDays(7), p.WarningDeadline);
+        Assert.Equal(TimeSpan.FromDays(30), p.InfoDeadline);
+        Assert.Equal("Enterprise", p.Name);
+    }
+
+    [Fact]
+    public void Strict_Policy_Has_Shorter_Deadlines()
+    {
+        var p = SlaTracker.SlaPolicy.Strict;
+        Assert.Equal(TimeSpan.FromHours(4), p.CriticalDeadline);
+        Assert.Equal(TimeSpan.FromHours(48), p.WarningDeadline);
+        Assert.Equal(TimeSpan.FromDays(14), p.InfoDeadline);
+    }
+
+    [Fact]
+    public void Relaxed_Policy_Has_Longer_Deadlines()
+    {
+        var p = SlaTracker.SlaPolicy.Relaxed;
+        Assert.Equal(TimeSpan.FromHours(72), p.CriticalDeadline);
+        Assert.Equal(TimeSpan.FromDays(30), p.WarningDeadline);
+        Assert.Equal(TimeSpan.FromDays(90), p.InfoDeadline);
+    }
+
+    [Fact]
+    public void GetDeadline_Returns_MaxValue_For_Pass()
+    {
+        var p = SlaTracker.SlaPolicy.Enterprise;
+        Assert.Equal(TimeSpan.MaxValue, p.GetDeadline(Severity.Pass));
+    }
+
+    // ── Track ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Track_Assigns_Sequential_Ids()
+    {
+        var tracker = new SlaTracker();
+        var f1 = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+        var f2 = tracker.Track(MakeFinding(Severity.Warning), _baseTime);
+
+        Assert.Equal("SLA-0001", f1.Id);
+        Assert.Equal("SLA-0002", f2.Id);
+    }
+
+    [Fact]
+    public void Track_Sets_Correct_Deadline()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        Assert.Equal(_baseTime + TimeSpan.FromHours(24), f.Deadline);
+        Assert.True(f.IsOpen);
+    }
+
+    [Fact]
+    public void Track_Warning_Gets_7Day_Deadline()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Warning), _baseTime);
+
+        Assert.Equal(_baseTime + TimeSpan.FromDays(7), f.Deadline);
+    }
+
+    [Fact]
+    public void Track_Pass_Gets_MaxValue_Deadline()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Pass), _baseTime);
+
+        Assert.Equal(DateTimeOffset.MaxValue, f.Deadline);
+    }
+
+    [Fact]
+    public void Track_Null_Finding_Throws()
+    {
+        var tracker = new SlaTracker();
+        Assert.Throws<ArgumentNullException>(() => tracker.Track(null!));
+    }
+
+    // ── TrackReport ──────────────────────────────────────────────
+
+    [Fact]
+    public void TrackReport_Imports_All_NonPass_Findings()
+    {
+        var report = new SecurityReport
+        {
+            GeneratedAt = _baseTime,
+            Results = new List<AuditResult>
+            {
+                new()
+                {
+                    ModuleName = "Firewall",
+                    Category = "Network",
+                    Findings = new List<Finding>
+                    {
+                        MakeFinding(Severity.Critical, "Open RDP"),
+                        MakeFinding(Severity.Warning, "Weak Rule"),
+                        MakeFinding(Severity.Pass, "ICMP OK"),
+                    }
+                }
+            }
+        };
+
+        var tracker = new SlaTracker();
+        var count = tracker.TrackReport(report);
+
+        Assert.Equal(2, count);  // Pass is skipped
+        Assert.Equal(2, tracker.Findings.Count);
+    }
+
+    [Fact]
+    public void TrackReport_Uses_Report_Timestamp()
+    {
+        var report = new SecurityReport
+        {
+            GeneratedAt = _baseTime,
+            Results = new List<AuditResult>
+            {
+                new()
+                {
+                    ModuleName = "Mod",
+                    Category = "Cat",
+                    Findings = new List<Finding> { MakeFinding(Severity.Warning, "Test") }
+                }
+            }
+        };
+
+        var tracker = new SlaTracker();
+        tracker.TrackReport(report);
+
+        Assert.Equal(_baseTime, tracker.Findings[0].DetectedAt);
+    }
+
+    // ── Resolve ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Resolve_Marks_Finding_Resolved()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        var resolved = tracker.Resolve(f.Id, _baseTime + TimeSpan.FromHours(12));
+
+        Assert.False(resolved.IsOpen);
+        Assert.Equal(_baseTime + TimeSpan.FromHours(12), resolved.ResolvedAt);
+    }
+
+    [Fact]
+    public void Resolve_Within_Sla_Sets_MetSla()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        tracker.Resolve(f.Id, _baseTime + TimeSpan.FromHours(12));
+
+        Assert.True(f.MetSla);
+    }
+
+    [Fact]
+    public void Resolve_After_Deadline_MissedSla()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        tracker.Resolve(f.Id, _baseTime + TimeSpan.FromHours(48));
+
+        Assert.False(f.MetSla);
+    }
+
+    [Fact]
+    public void Resolve_Unknown_Id_Throws()
+    {
+        var tracker = new SlaTracker();
+        Assert.Throws<ArgumentException>(() => tracker.Resolve("SLA-9999"));
+    }
+
+    [Fact]
+    public void Resolve_Already_Resolved_Throws()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Warning), _baseTime);
+        tracker.Resolve(f.Id, _baseTime + TimeSpan.FromHours(1));
+
+        Assert.Throws<InvalidOperationException>(() => tracker.Resolve(f.Id));
+    }
+
+    [Fact]
+    public void Resolve_Stores_Notes()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Warning), _baseTime);
+
+        tracker.Resolve(f.Id, notes: "Applied patch KB-12345");
+
+        Assert.Equal("Applied patch KB-12345", f.ResolutionNotes);
+    }
+
+    // ── ResolveByTitle ───────────────────────────────────────────
+
+    [Fact]
+    public void ResolveByTitle_Matches_Substring()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "Open RDP Port"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "Open SSH Port"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "Weak Password"), _baseTime);
+
+        var count = tracker.ResolveByTitle("Open", _baseTime + TimeSpan.FromHours(2));
+
+        Assert.Equal(2, count);
+        Assert.Equal(1, tracker.GetOpen().Count);
+    }
+
+    // ── Assess ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Assess_OnTrack_When_Within_Window()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        var assessment = tracker.Assess(f, _baseTime + TimeSpan.FromHours(6));
+
+        Assert.Equal(SlaTracker.SlaStatus.OnTrack, assessment.Status);
+        Assert.True(assessment.TimeRemaining > TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void Assess_Approaching_When_Past_Threshold()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        // 75% of 24h = 18h, so at 20h it should be "approaching"
+        var assessment = tracker.Assess(f, _baseTime + TimeSpan.FromHours(20));
+
+        Assert.Equal(SlaTracker.SlaStatus.Approaching, assessment.Status);
+    }
+
+    [Fact]
+    public void Assess_Overdue_When_Past_Deadline()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        var assessment = tracker.Assess(f, _baseTime + TimeSpan.FromHours(30));
+
+        Assert.Equal(SlaTracker.SlaStatus.Overdue, assessment.Status);
+        Assert.True(assessment.TimeRemaining < TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void Assess_Resolved_Finding()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Warning), _baseTime);
+        tracker.Resolve(f.Id, _baseTime + TimeSpan.FromDays(3));
+
+        var assessment = tracker.Assess(f, _baseTime + TimeSpan.FromDays(10));
+
+        Assert.Equal(SlaTracker.SlaStatus.Resolved, assessment.Status);
+        Assert.Contains("within SLA", assessment.UrgencyLabel);
+    }
+
+    [Fact]
+    public void Assess_Resolved_After_Sla()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+        tracker.Resolve(f.Id, _baseTime + TimeSpan.FromHours(48));
+
+        var assessment = tracker.Assess(f);
+
+        Assert.Contains("AFTER SLA", assessment.UrgencyLabel);
+    }
+
+    [Fact]
+    public void Assess_Pass_Finding_Is_Exempt()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Pass), _baseTime);
+
+        var assessment = tracker.Assess(f);
+
+        Assert.Equal(SlaTracker.SlaStatus.Exempt, assessment.Status);
+    }
+
+    // ── GenerateReport ───────────────────────────────────────────
+
+    [Fact]
+    public void GenerateReport_Empty_Tracker()
+    {
+        var tracker = new SlaTracker();
+        var report = tracker.GenerateReport();
+
+        Assert.Equal(0, report.TotalTracked);
+        Assert.Equal(100.0, report.CompliancePercent);
+    }
+
+    [Fact]
+    public void GenerateReport_Counts_Correct()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "F1"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "F2"), _baseTime);
+        var f3 = tracker.Track(MakeFinding(Severity.Warning, "F3"), _baseTime);
+        tracker.Resolve(f3.Id, _baseTime + TimeSpan.FromDays(2));
+
+        var report = tracker.GenerateReport(_baseTime + TimeSpan.FromDays(3));
+
+        Assert.Equal(3, report.TotalTracked);
+        Assert.Equal(2, report.OpenCount);
+        Assert.Equal(1, report.ResolvedCount);
+    }
+
+    [Fact]
+    public void GenerateReport_Compliance_100_When_All_Met()
+    {
+        var tracker = new SlaTracker();
+        var f1 = tracker.Track(MakeFinding(Severity.Critical, "F1"), _baseTime);
+        var f2 = tracker.Track(MakeFinding(Severity.Warning, "F2"), _baseTime);
+        tracker.Resolve(f1.Id, _baseTime + TimeSpan.FromHours(12));  // within 24h
+        tracker.Resolve(f2.Id, _baseTime + TimeSpan.FromDays(3));    // within 7d
+
+        var report = tracker.GenerateReport();
+
+        Assert.Equal(100.0, report.CompliancePercent);
+    }
+
+    [Fact]
+    public void GenerateReport_Compliance_50_When_Half_Missed()
+    {
+        var tracker = new SlaTracker();
+        var f1 = tracker.Track(MakeFinding(Severity.Critical, "F1"), _baseTime);
+        var f2 = tracker.Track(MakeFinding(Severity.Critical, "F2"), _baseTime);
+        tracker.Resolve(f1.Id, _baseTime + TimeSpan.FromHours(12));  // within SLA
+        tracker.Resolve(f2.Id, _baseTime + TimeSpan.FromHours(48));  // missed SLA
+
+        var report = tracker.GenerateReport();
+
+        Assert.Equal(50.0, report.CompliancePercent);
+    }
+
+    [Fact]
+    public void GenerateReport_MTTR_Calculated()
+    {
+        var tracker = new SlaTracker();
+        var f1 = tracker.Track(MakeFinding(Severity.Warning, "F1"), _baseTime);
+        var f2 = tracker.Track(MakeFinding(Severity.Warning, "F2"), _baseTime);
+        tracker.Resolve(f1.Id, _baseTime + TimeSpan.FromHours(10));
+        tracker.Resolve(f2.Id, _baseTime + TimeSpan.FromHours(20));
+
+        var report = tracker.GenerateReport();
+
+        Assert.NotNull(report.MeanTimeToRemediate);
+        Assert.Equal(15.0, report.MeanTimeToRemediate.Value.TotalHours, 1);
+    }
+
+    [Fact]
+    public void GenerateReport_BySeverity_Breakdown()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "C1"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Critical, "C2"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "W1"), _baseTime);
+
+        var report = tracker.GenerateReport(_baseTime + TimeSpan.FromHours(1));
+
+        Assert.Equal(2, report.BySeverity[Severity.Critical].Total);
+        Assert.Equal(1, report.BySeverity[Severity.Warning].Total);
+    }
+
+    [Fact]
+    public void GenerateReport_Overdue_List()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "Overdue1"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "OnTrack1"), _baseTime);
+
+        // 48h later: critical is overdue (24h SLA), warning is still on track (7d SLA)
+        var report = tracker.GenerateReport(_baseTime + TimeSpan.FromHours(48));
+
+        Assert.Single(report.TopOverdue);
+        Assert.Equal("Overdue1", report.TopOverdue[0].Finding.Title);
+    }
+
+    [Fact]
+    public void GenerateReport_Assessments_Ordered_By_Urgency()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Info, "Info1"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Critical, "Crit1"), _baseTime);
+
+        // Check at 30h: critical is overdue, info is on track
+        var report = tracker.GenerateReport(_baseTime + TimeSpan.FromHours(30));
+
+        // Overdue findings should come first
+        Assert.Equal(SlaTracker.SlaStatus.Overdue, report.Assessments[0].Status);
+    }
+
+    // ── Query helpers ────────────────────────────────────────────
+
+    [Fact]
+    public void GetOpen_Returns_Only_Open()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "F1"), _baseTime);
+        var f2 = tracker.Track(MakeFinding(Severity.Warning, "F2"), _baseTime);
+        tracker.Resolve(f2.Id);
+
+        Assert.Single(tracker.GetOpen());
+        Assert.Equal("F1", tracker.GetOpen()[0].Title);
+    }
+
+    [Fact]
+    public void GetOverdue_Returns_Past_Deadline()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "F1"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "F2"), _baseTime);
+
+        var overdue = tracker.GetOverdue(_baseTime + TimeSpan.FromHours(48));
+
+        Assert.Single(overdue);  // Only critical is overdue at 48h
+        Assert.Equal("F1", overdue[0].Title);
+    }
+
+    [Fact]
+    public void GetApproaching_Returns_Near_Deadline()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "F1"), _baseTime);
+
+        // At 20h into 24h deadline (83%), past 75% threshold
+        var approaching = tracker.GetApproaching(_baseTime + TimeSpan.FromHours(20));
+
+        Assert.Single(approaching);
+    }
+
+    [Fact]
+    public void GetById_Returns_Correct_Finding()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Warning, "Specific"), _baseTime);
+
+        Assert.Equal("Specific", tracker.GetById(f.Id)?.Title);
+        Assert.Null(tracker.GetById("SLA-9999"));
+    }
+
+    [Fact]
+    public void GetByCategory_Filters_Correctly()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Warning, "F1", "Network"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "F2", "Firewall"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Critical, "F3", "Network"), _baseTime);
+
+        Assert.Equal(2, tracker.GetByCategory("Network").Count);
+        Assert.Single(tracker.GetByCategory("Firewall"));
+    }
+
+    [Fact]
+    public void GetBySeverity_Filters_Correctly()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "C1"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Critical, "C2"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "W1"), _baseTime);
+
+        Assert.Equal(2, tracker.GetBySeverity(Severity.Critical).Count);
+        Assert.Single(tracker.GetBySeverity(Severity.Warning));
+    }
+
+    // ── Export / Import ──────────────────────────────────────────
+
+    [Fact]
+    public void ExportJson_RoundTrips()
+    {
+        var tracker = new SlaTracker();
+        var f1 = tracker.Track(MakeFinding(Severity.Critical, "Crit1", "Network"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "Warn1", "Firewall"), _baseTime);
+        tracker.Resolve(f1.Id, _baseTime + TimeSpan.FromHours(12), "Patched");
+
+        var json = tracker.ExportJson();
+
+        var tracker2 = new SlaTracker();
+        var count = tracker2.ImportJson(json);
+
+        Assert.Equal(2, count);
+        Assert.Equal(2, tracker2.Findings.Count);
+        Assert.Equal("Crit1", tracker2.Findings[0].Title);
+        Assert.False(tracker2.Findings[0].IsOpen);
+        Assert.Equal("Patched", tracker2.Findings[0].ResolutionNotes);
+    }
+
+    [Fact]
+    public void ImportJson_Continues_Id_Sequence()
+    {
+        var tracker = new SlaTracker();
+        tracker.ImportJson("{\"findings\":[{\"Id\":\"SLA-0005\",\"Title\":\"T\",\"Category\":\"C\"," +
+            "\"Severity\":\"Warning\",\"DetectedAt\":\"2026-01-01T00:00:00Z\"," +
+            "\"Deadline\":\"2026-01-08T00:00:00Z\"}]}");
+
+        var f = tracker.Track(MakeFinding(Severity.Info, "New"), _baseTime);
+        Assert.Equal("SLA-0006", f.Id);
+    }
+
+    [Fact]
+    public void ImportJson_Invalid_Throws()
+    {
+        var tracker = new SlaTracker();
+        Assert.Throws<ArgumentException>(() => tracker.ImportJson("{}"));
+    }
+
+    // ── Custom policy ────────────────────────────────────────────
+
+    [Fact]
+    public void Custom_Policy_Applied()
+    {
+        var policy = new SlaTracker.SlaPolicy
+        {
+            Name = "Custom",
+            CriticalDeadline = TimeSpan.FromHours(2),
+            WarningDeadline = TimeSpan.FromHours(12),
+            InfoDeadline = TimeSpan.FromDays(3),
+        };
+
+        var tracker = new SlaTracker(policy);
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        Assert.Equal(_baseTime + TimeSpan.FromHours(2), f.Deadline);
+    }
+
+    [Fact]
+    public void Strict_Policy_Flags_Approaching_Earlier()
+    {
+        var tracker = new SlaTracker(SlaTracker.SlaPolicy.Strict);
+        // Strict: Critical = 4h, ApproachingThreshold = 0.5
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        // At 3h into 4h deadline (75%), past 50% threshold
+        var assessment = tracker.Assess(f, _baseTime + TimeSpan.FromHours(3));
+
+        Assert.Equal(SlaTracker.SlaStatus.Approaching, assessment.Status);
+    }
+
+    // ── Text report ──────────────────────────────────────────────
+
+    [Fact]
+    public void GenerateTextReport_Contains_Key_Sections()
+    {
+        var tracker = new SlaTracker();
+        tracker.Track(MakeFinding(Severity.Critical, "Open Port"), _baseTime);
+        tracker.Track(MakeFinding(Severity.Warning, "Weak Cipher"), _baseTime);
+        var f = tracker.Track(MakeFinding(Severity.Info, "Old Software"), _baseTime);
+        tracker.Resolve(f.Id, _baseTime + TimeSpan.FromDays(5));
+
+        var text = tracker.GenerateTextReport(_baseTime + TimeSpan.FromHours(30));
+
+        Assert.Contains("SLA Compliance Report", text);
+        Assert.Contains("Total Tracked:", text);
+        Assert.Contains("OVERDUE", text);
+        Assert.Contains("Open Port", text);
+        Assert.Contains("By Severity", text);
+    }
+
+    [Fact]
+    public void GenerateTextReport_Empty_Tracker()
+    {
+        var tracker = new SlaTracker();
+        var text = tracker.GenerateTextReport();
+
+        Assert.Contains("SLA Compliance Report", text);
+        Assert.Contains("Total Tracked:    0", text);
+    }
+
+    // ── WindowConsumed ───────────────────────────────────────────
+
+    [Fact]
+    public void WindowConsumed_Is_Correct_Fraction()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        // 12h into 24h deadline = 0.5
+        var assessment = tracker.Assess(f, _baseTime + TimeSpan.FromHours(12));
+
+        Assert.Equal(0.5, assessment.WindowConsumed, 2);
+    }
+
+    [Fact]
+    public void WindowConsumed_Exceeds_1_When_Overdue()
+    {
+        var tracker = new SlaTracker();
+        var f = tracker.Track(MakeFinding(Severity.Critical), _baseTime);
+
+        var assessment = tracker.Assess(f, _baseTime + TimeSpan.FromHours(48));
+
+        Assert.True(assessment.WindowConsumed > 1.0);
+    }
+}


### PR DESCRIPTION
Track remediation SLAs for security findings by severity level.

**Problem:** Security teams need to track remediation deadlines for compliance (SOC2, HIPAA, ISO 27001). No existing service tracks whether findings are remediated within required timeframes.

**Solution:** \SlaTracker\ service with configurable SLA policies per severity:

**SLA Policies:**
- **Enterprise** (default): Critical 24h, Warning 7d, Info 30d
- **Strict**: Critical 4h, Warning 48h, Info 14d
- **Relaxed**: Critical 72h, Warning 30d, Info 90d
- Custom: fully configurable

**Features:**
- \Track(finding)\ / \TrackReport(report)\ — begin tracking with auto-deadline
- \Resolve(id)\ / \ResolveByTitle(pattern)\ — mark remediated
- \Assess(finding)\ — check SLA status (OnTrack/Approaching/Overdue/Resolved/Exempt)
- \GenerateReport()\ — full compliance report: overall %, per-severity breakdown, MTTR, top overdue, approaching deadline
- \GetOverdue()\ / \GetApproaching()\ — urgent item queries
- JSON export/import for persistence
- Plain-text report generation

**47 xUnit tests, all passing.**