### PR TITLE
fix: double-escaping of single quotes in toast notifications

### DIFF
--- a/src/WinSentinel.Core/Services/NotificationService.cs
+++ b/src/WinSentinel.Core/Services/NotificationService.cs
@@ -137,8 +137,11 @@ public class WindowsToastSender : IToastSender
 
     private static void SendToastViaPowerShell(string title, string body)
     {
-        var escapedTitle = title.Replace("'", "''").Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
-        var escapedBody = body.Replace("'", "''").Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\n", "&#10;");
+        // XML-escape only — single-quote escaping for PowerShell is handled later
+        // by xml.Replace("'", "''") on the full XML string. Escaping here AND there
+        // causes double-escaping: it's → it''s → it''''s in the PS string.
+        var escapedTitle = title.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+        var escapedBody = body.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\n", "&#10;");
 
         var xml = $@"<toast>
   <visual>


### PR DESCRIPTION
SendToastViaPowerShell escaped single quotes in title/body AND in the full XML string, causing double-escaping. Text like "it's" became "it''''s" in the PowerShell string, displaying as "it''s" in toast notifications.

Fix: Removed the redundant .Replace("'", "''") from escapedTitle/escapedBody — XML doesn't require single-quote escaping. The PowerShell-level escape on the full XML string handles it correctly.
