### PR TITLE
fix: normalize timestamps to UTC for correct chronological comparison

### DIFF
--- a/src/WinSentinel.Core/Services/AuditHistoryService.cs
+++ b/src/WinSentinel.Core/Services/AuditHistoryService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Data.Sqlite;
 using WinSentinel.Core.Models;
 
@@ -125,7 +126,7 @@ public class AuditHistoryService : IDisposable
                 VALUES (@ts, @score, @grade, @total, @critical, @warning, @info, @pass, @scheduled);
                 SELECT last_insert_rowid();
             ";
-            runCmd.Parameters.AddWithValue("@ts", report.GeneratedAt.ToString("o"));
+            runCmd.Parameters.AddWithValue("@ts", report.GeneratedAt.ToUniversalTime().ToString("o"));
             runCmd.Parameters.AddWithValue("@score", report.SecurityScore);
             runCmd.Parameters.AddWithValue("@grade", SecurityScorer.GetGrade(report.SecurityScore));
             runCmd.Parameters.AddWithValue("@total", report.TotalFindings);
@@ -229,7 +230,7 @@ public class AuditHistoryService : IDisposable
             runs.Add(new AuditRunRecord
             {
                 Id = reader.GetInt64(0),
-                Timestamp = DateTimeOffset.Parse(reader.GetString(1)),
+                Timestamp = DateTimeOffset.Parse(reader.GetString(1), CultureInfo.InvariantCulture),
                 OverallScore = reader.GetInt32(2),
                 Grade = reader.GetString(3),
                 TotalFindings = reader.GetInt32(4),
@@ -271,7 +272,7 @@ public class AuditHistoryService : IDisposable
             runs.Add(new AuditRunRecord
             {
                 Id = reader.GetInt64(0),
-                Timestamp = DateTimeOffset.Parse(reader.GetString(1)),
+                Timestamp = DateTimeOffset.Parse(reader.GetString(1), CultureInfo.InvariantCulture),
                 OverallScore = reader.GetInt32(2),
                 Grade = reader.GetString(3),
                 TotalFindings = reader.GetInt32(4),
@@ -312,7 +313,7 @@ public class AuditHistoryService : IDisposable
                 run = new AuditRunRecord
                 {
                     Id = reader.GetInt64(0),
-                    Timestamp = DateTimeOffset.Parse(reader.GetString(1)),
+                    Timestamp = DateTimeOffset.Parse(reader.GetString(1), CultureInfo.InvariantCulture),
                     OverallScore = reader.GetInt32(2),
                     Grade = reader.GetString(3),
                     TotalFindings = reader.GetInt32(4),


### PR DESCRIPTION
Fixes #74

**Problem:** `AuditHistoryService` stored timestamps with the local timezone offset (e.g. `-07:00`) but compared them against UTC cutoffs using SQL string comparison. On non-UTC machines, this produced incorrect chronological ordering.

**Fix:**
- Normalize all timestamps to UTC before storing via `ToUniversalTime()`
- Add `CultureInfo.InvariantCulture` to all `DateTimeOffset.Parse` calls
