### PR TITLE
fix: normalize AuditHistoryService timestamps to UTC

### DIFF
--- a/src/WinSentinel.Core/Services/AuditHistoryService.cs
+++ b/src/WinSentinel.Core/Services/AuditHistoryService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Data.Sqlite;
 using WinSentinel.Core.Models;
 
@@ -125,7 +126,7 @@ public class AuditHistoryService : IDisposable
                 VALUES (@ts, @score, @grade, @total, @critical, @warning, @info, @pass, @scheduled);
                 SELECT last_insert_rowid();
             ";
-            runCmd.Parameters.AddWithValue("@ts", report.GeneratedAt.ToString("o"));
+            runCmd.Parameters.AddWithValue("@ts", report.GeneratedAt.ToUniversalTime().ToString("o"));
             runCmd.Parameters.AddWithValue("@score", report.SecurityScore);
             runCmd.Parameters.AddWithValue("@grade", SecurityScorer.GetGrade(report.SecurityScore));
             runCmd.Parameters.AddWithValue("@total", report.TotalFindings);
@@ -229,7 +230,7 @@ public class AuditHistoryService : IDisposable
             runs.Add(new AuditRunRecord
             {
                 Id = reader.GetInt64(0),
-                Timestamp = DateTimeOffset.Parse(reader.GetString(1)),
+                Timestamp = DateTimeOffset.Parse(reader.GetString(1), CultureInfo.InvariantCulture),
                 OverallScore = reader.GetInt32(2),
                 Grade = reader.GetString(3),
                 TotalFindings = reader.GetInt32(4),
@@ -271,7 +272,7 @@ public class AuditHistoryService : IDisposable
             runs.Add(new AuditRunRecord
             {
                 Id = reader.GetInt64(0),
-                Timestamp = DateTimeOffset.Parse(reader.GetString(1)),
+                Timestamp = DateTimeOffset.Parse(reader.GetString(1), CultureInfo.InvariantCulture),
                 OverallScore = reader.GetInt32(2),
                 Grade = reader.GetString(3),
                 TotalFindings = reader.GetInt32(4),
@@ -312,7 +313,7 @@ public class AuditHistoryService : IDisposable
                 run = new AuditRunRecord
                 {
                     Id = reader.GetInt64(0),
-                    Timestamp = DateTimeOffset.Parse(reader.GetString(1)),
+                    Timestamp = DateTimeOffset.Parse(reader.GetString(1), CultureInfo.InvariantCulture),
                     OverallScore = reader.GetInt32(2),
                     Grade = reader.GetString(3),
                     TotalFindings = reader.GetInt32(4),


### PR DESCRIPTION
## Summary

Fixes #74 — AuditHistoryService string comparison of ISO 8601 timestamps breaks with different timezone offsets.

## Changes

- **SaveAuditResult**: Normalize GeneratedAt to UTC before storing (.ToUniversalTime().ToString("o"))
- **All DateTimeOffset.Parse calls**: Added CultureInfo.InvariantCulture for consistent parsing across locales

## Root Cause

Timestamps were stored with the original timezone offset. SQL WHERE Timestamp >= @cutoff does string comparison, which fails when offsets differ.

## Impact

Fixes GetHistory, PurgeOldRuns, and ORDER BY Timestamp on any machine where timezone is not UTC.
