### PR TITLE
chore: rename BadgeBadgeAction typo + update audit module docs (13 to 30)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,23 +222,40 @@ The `FixEngine` handles executing fix commands safely:
 4. **Output capture:** Captures stdout/stderr for success/failure reporting
 5. **Dry-run mode:** Returns what would be done without executing
 
-### The 13 Audit Modules
+### The 30 Audit Modules
 
-| Module | Key Windows APIs Used |
+| Module | Key Windows APIs / Techniques |
 |:---|:---|
-| `FirewallAudit` | `netsh advfirewall`, WMI `Win32_Process` |
-| `UpdateAudit` | `Get-WindowsUpdateLog`, COM `IUpdateSearcher` |
-| `DefenderAudit` | `Get-MpPreference`, `Get-MpComputerStatus` |
-| `AccountAudit` | `net user`, `Get-LocalUser`, `net accounts` |
-| `NetworkAudit` | `netstat`, `Get-NetTCPConnection`, ARP table |
-| `ProcessAudit` | `Process.GetProcesses()`, `Authenticode` verification |
-| `StartupAudit` | Registry `Run`/`RunOnce` keys, `Get-ScheduledTask` |
-| `SystemAudit` | `Confirm-SecureBootUEFI`, `manage-bde`, Registry for UAC/RDP/DEP |
-| `PrivacyAudit` | Registry telemetry keys, location/clipboard/advertising settings |
-| `BrowserAudit` | Chrome/Edge JSON preferences files, extension manifests |
+| `AccountAudit` | `net user`, `Get-LocalUser`, `net accounts`, password policies |
 | `AppSecurityAudit` | `Get-Package`, installed software version analysis |
-| `EncryptionAudit` | `manage-bde -status`, TPM via WMI, certificate store |
-| `EventLogAudit` | `Get-WinEvent`, Security log analysis |
+| `BackupAudit` | Shadow copies, System Restore, backup schedules, `vssadmin` |
+| `BluetoothAudit` | Bluetooth adapter state, paired devices, discoverability |
+| `BrowserAudit` | Chrome/Edge JSON preferences, extension manifests, security settings |
+| `CertificateAudit` | Certificate store analysis, expiration, weak algorithms |
+| `CredentialExposureAudit` | Credential caching, WDigest, LSA protection, LSASS hardening |
+| `DefenderAudit` | `Get-MpPreference`, `Get-MpComputerStatus`, real-time protection |
+| `DnsAudit` | DNS client config, DNS-over-HTTPS, DNS cache poisoning vectors |
+| `DriverAudit` | `driverquery`, unsigned drivers, vulnerable driver blocklist |
+| `EncryptionAudit` | `manage-bde -status`, TPM via WMI, TLS/SSL protocol config |
+| `EnvironmentAudit` | PATH hijacking, temp directory permissions, env variable security |
+| `EventLogAudit` | `Get-WinEvent`, security log analysis, audit policy gaps |
+| `FirewallAudit` | `netsh advfirewall`, profile states, inbound rule analysis |
+| `GroupPolicyAudit` | `gpresult`, applied GPOs, security-relevant policy settings |
+| `NetworkAudit` | `netstat`, `Get-NetTCPConnection`, ARP table, LLMNR/mDNS |
+| `PowerShellAudit` | Execution policy, script block logging, constrained language mode |
+| `PrivacyAudit` | Registry telemetry keys, location/clipboard/advertising settings |
+| `ProcessAudit` | `Process.GetProcesses()`, `Authenticode` verification, suspicious paths |
+| `RegistryAudit` | Critical registry key ACLs, autorun entries, security settings |
+| `RemoteAccessAudit` | RDP configuration, remote management, WinRM settings |
+| `ScheduledTaskAudit` | `Get-ScheduledTask`, suspicious task actions, privilege escalation |
+| `ServiceAudit` | Service configurations, unquoted paths, writable service binaries |
+| `SmbShareAudit` | Network share permissions, SMBv1, null sessions |
+| `SoftwareInventoryAudit` | Installed software catalog, EOL detection, vulnerability correlation |
+| `StartupAudit` | Registry `Run`/`RunOnce` keys, startup folder, shell extensions |
+| `SystemAudit` | Secure Boot, BitLocker, UAC, RDP, DEP, ASLR configuration |
+| `UpdateAudit` | `Get-WindowsUpdateLog`, Windows Update status, pending patches |
+| `VirtualizationAudit` | Hyper-V, WSL, sandbox isolation, VM escape mitigations |
+| `WifiAudit` | Saved Wi-Fi profiles, encryption strength, open network detection |
 
 ## IPC Protocol
 

--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -43,7 +43,7 @@ public class CliOptions
     public int TrendDays { get; set; } = 30;
     public int? TrendAlertThreshold { get; set; }
     public bool TrendModules { get; set; }
-    public BadgeBadgeAction BadgeAction { get; set; } = BadgeBadgeAction.None;
+    public BadgeAction BadgeAction { get; set; } = BadgeAction.None;
     public string? BadgeStyle { get; set; }
     public string? TimelineSeverityFilter { get; set; }
     public int? TimelineMaxEvents { get; set; }
@@ -123,7 +123,7 @@ public enum IgnoreAction
     Purge
 }
 
-public enum BadgeBadgeAction
+public enum BadgeAction
 {
     None,
     Score,
@@ -547,20 +547,20 @@ public static class CliParser
                         var badgeType = args[++i].ToLowerInvariant();
                         options.BadgeAction = badgeType switch
                         {
-                            "score" => BadgeBadgeAction.Score,
-                            "grade" => BadgeBadgeAction.Grade,
-                            "findings" => BadgeBadgeAction.Findings,
-                            "module" => BadgeBadgeAction.Module,
-                            "all" => BadgeBadgeAction.All,
-                            _ => BadgeBadgeAction.None
+                            "score" => BadgeAction.Score,
+                            "grade" => BadgeAction.Grade,
+                            "findings" => BadgeAction.Findings,
+                            "module" => BadgeAction.Module,
+                            "all" => BadgeAction.All,
+                            _ => BadgeAction.None
                         };
-                        if (options.BadgeAction == BadgeBadgeAction.None)
+                        if (options.BadgeAction == BadgeAction.None)
                         {
                             options.Error = $"Unknown badge type: {badgeType}. Use score, grade, findings, module, or all.";
                             return options;
                         }
                         // For module: next arg is the module filter
-                        if (options.BadgeAction == BadgeBadgeAction.Module)
+                        if (options.BadgeAction == BadgeAction.Module)
                         {
                             if (i + 1 < args.Length && !args[i + 1].StartsWith("-"))
                             {
@@ -571,7 +571,7 @@ public static class CliParser
                     else
                     {
                         // Default to score badge
-                        options.BadgeAction = BadgeBadgeAction.Score;
+                        options.BadgeAction = BadgeAction.Score;
                     }
                     break;
 

--- a/tests/WinSentinel.Tests/Cli/CliParserTests.cs
+++ b/tests/WinSentinel.Tests/Cli/CliParserTests.cs
@@ -1076,17 +1076,17 @@ public class CliParserTests
     {
         var result = CliParser.Parse(["--badge"]);
         Assert.Equal(CliCommand.Badge, result.Command);
-        Assert.Equal(BadgeBadgeAction.Score, result.BadgeAction);
+        Assert.Equal(BadgeAction.Score, result.BadgeAction);
         Assert.Null(result.Error);
     }
 
     [Theory]
-    [InlineData("score", BadgeBadgeAction.Score)]
-    [InlineData("grade", BadgeBadgeAction.Grade)]
-    [InlineData("findings", BadgeBadgeAction.Findings)]
-    [InlineData("module", BadgeBadgeAction.Module)]
-    [InlineData("all", BadgeBadgeAction.All)]
-    public void Parse_Badge_AllTypes(string type, BadgeBadgeAction expected)
+    [InlineData("score", BadgeAction.Score)]
+    [InlineData("grade", BadgeAction.Grade)]
+    [InlineData("findings", BadgeAction.Findings)]
+    [InlineData("module", BadgeAction.Module)]
+    [InlineData("all", BadgeAction.All)]
+    public void Parse_Badge_AllTypes(string type, BadgeAction expected)
     {
         var result = CliParser.Parse(["--badge", type]);
         Assert.Equal(CliCommand.Badge, result.Command);
@@ -1107,7 +1107,7 @@ public class CliParserTests
     {
         var result = CliParser.Parse(["--badge", "module", "Firewall"]);
         Assert.Equal(CliCommand.Badge, result.Command);
-        Assert.Equal(BadgeBadgeAction.Module, result.BadgeAction);
+        Assert.Equal(BadgeAction.Module, result.BadgeAction);
         Assert.Equal("Firewall", result.ModulesFilter);
     }
 
@@ -1116,7 +1116,7 @@ public class CliParserTests
     {
         var result = CliParser.Parse(["--badge", "score", "-o", "badge.svg"]);
         Assert.Equal(CliCommand.Badge, result.Command);
-        Assert.Equal(BadgeBadgeAction.Score, result.BadgeAction);
+        Assert.Equal(BadgeAction.Score, result.BadgeAction);
         Assert.Equal("badge.svg", result.OutputFile);
     }
 
@@ -1153,7 +1153,7 @@ public class CliParserTests
     {
         var result = CliParser.Parse(["--badge", "all", "--json"]);
         Assert.Equal(CliCommand.Badge, result.Command);
-        Assert.Equal(BadgeBadgeAction.All, result.BadgeAction);
+        Assert.Equal(BadgeAction.All, result.BadgeAction);
         Assert.True(result.Json);
     }
 
@@ -1161,7 +1161,7 @@ public class CliParserTests
     public void CliOptions_BadgeDefaults()
     {
         var options = new CliOptions();
-        Assert.Equal(BadgeBadgeAction.None, options.BadgeAction);
+        Assert.Equal(BadgeAction.None, options.BadgeAction);
         Assert.Null(options.BadgeStyle);
     }
 }


### PR DESCRIPTION
## Code Cleanup + Doc Update

### Code Cleanup: `BadgeBadgeAction` → `BadgeAction`

The `BadgeBadgeAction` enum had a naming typo — the "Badge" prefix was doubled. Renamed to `BadgeAction` across all 23 references in `CliParser.cs` and `CliParserTests.cs`. The property on `CliOptions` was already correctly named `BadgeAction`, making the mismatch more obvious.

### Doc Update: ARCHITECTURE.md audit modules (13 → 30)

The "13 Audit Modules" table in ARCHITECTURE.md was outdated — WinSentinel now has **30 audit modules**. Updated the section with all current modules and their key Windows APIs / detection techniques:

**17 new modules added to docs:**
`BackupAudit`, `BluetoothAudit`, `CertificateAudit`, `CredentialExposureAudit`, `DnsAudit`, `DriverAudit`, `EnvironmentAudit`, `GroupPolicyAudit`, `PowerShellAudit`, `RegistryAudit`, `RemoteAccessAudit`, `ScheduledTaskAudit`, `ServiceAudit`, `SmbShareAudit`, `SoftwareInventoryAudit`, `VirtualizationAudit`, `WifiAudit`
