### PR TITLE
fix: gate RapidMultiModule correlation on incoming event severity

### DIFF
--- a/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
+++ b/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
@@ -345,6 +345,13 @@ public class ThreatCorrelator
     /// </summary>
     internal void CheckRapidMultiModule(ThreatEvent newEvent, List<ThreatEvent> window, List<CorrelatedThreat> results)
     {
+        // Only trigger when the new event itself is significant — otherwise a
+        // low/info event (e.g. periodic heartbeat) arriving while the window
+        // already has 3+ medium+ sources would incorrectly fire a Critical
+        // "coordinated attack" correlation.
+        if (newEvent.Severity < ThreatSeverity.Medium)
+            return;
+
         // Only check for medium+ severity events
         var significantEvents = window.Where(e => e.Severity >= ThreatSeverity.Medium).ToList();
         var distinctSources = significantEvents.Select(e => e.Source).Distinct().ToList();


### PR DESCRIPTION
## Bug

\CheckRapidMultiModule\ in \ThreatCorrelator\ would fire a **Critical** 'coordinated attack' correlation whenever the sliding window already contained 3+ medium+ sources from different modules — regardless of the severity of the **new event** that triggered the check.

This means an **Info-level** event (e.g. a periodic heartbeat, benign log entry, or routine process start) could produce a false-positive Critical alert if the window happened to have stale medium+ events from 3+ modules.

## Fix

Added an early-return gate: the rule now only fires when the incoming event itself is at least **Medium** severity. This is consistent with how the window events are already filtered (\.Severity >= ThreatSeverity.Medium\).