### PR TITLE
feat: Attack Path Analyzer — kill chain analysis with chokepoint remediation

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -100,6 +100,7 @@ public enum CliCommand
     Threats,
     ScheduleOptimize,
     Digest,
+    AttackPaths,
     Help,
     Version
 }
@@ -397,6 +398,10 @@ public static class CliParser
 
                 case "--digest":
                     options.Command = CliCommand.Digest;
+                    break;
+
+                case "--attack-paths":
+                    options.Command = CliCommand.AttackPaths;
                     break;
 
                 case "--digest-days":

--- a/src/WinSentinel.Cli/ConsoleFormatter.AttackPaths.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.AttackPaths.cs
@@ -1,0 +1,208 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Cli;
+
+public static partial class ConsoleFormatter
+{
+    /// <summary>Print attack path analysis report.</summary>
+    public static void PrintAttackPaths(AttackPathAnalyzer.AttackPathReport report)
+    {
+        Console.WriteLine();
+        WriteLineColored("  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+        WriteLineColored("  ║       ⚔️  Attack Path Analysis               ║", ConsoleColor.Cyan);
+        WriteLineColored("  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        // Summary strip
+        var riskColor = report.OverallRisk switch
+        {
+            "Critical" => ConsoleColor.Red,
+            "High" => ConsoleColor.DarkYellow,
+            "Medium" => ConsoleColor.Yellow,
+            "Low" => ConsoleColor.Green,
+            _ => ConsoleColor.DarkGray
+        };
+        WriteColored("  Overall Risk: ", ConsoleColor.White);
+        WriteColored($"{report.OverallRisk}", riskColor);
+        WriteColored("  │  Paths: ", ConsoleColor.White);
+        WriteColored($"{report.Paths.Count}", ConsoleColor.Yellow);
+        WriteColored("  │  Findings in Paths: ", ConsoleColor.White);
+        WriteColored($"{report.FindingsInPaths}/{report.TotalFindings}", ConsoleColor.DarkGray);
+        Console.WriteLine();
+        Console.WriteLine();
+
+        // Stage Breakdown
+        WriteLineColored("  ── Kill Chain Stage Breakdown ──", ConsoleColor.DarkGray);
+        Console.WriteLine();
+
+        foreach (var (stage, count) in report.StageBreakdown)
+        {
+            var icon = stage switch
+            {
+                "Initial Access" => "🚪",
+                "Execution" => "⚙️",
+                "Persistence" => "📌",
+                "Privilege Escalation" => "⬆️",
+                "Lateral Movement" => "↔️",
+                "Exfiltration" => "📤",
+                _ => "•"
+            };
+
+            WriteColored($"    {icon} {stage,-24}", ConsoleColor.White);
+
+            if (count > 0)
+            {
+                var barLen = Math.Min(count * 2, 30);
+                WriteColored(new string('█', barLen), count > 3 ? ConsoleColor.Red : ConsoleColor.Yellow);
+                WriteLineColored($" {count} finding(s)", ConsoleColor.DarkGray);
+            }
+            else
+            {
+                WriteLineColored("  ✓ No exposures", ConsoleColor.Green);
+            }
+        }
+        Console.WriteLine();
+
+        // Attack Paths (top 10)
+        if (report.Paths.Count > 0)
+        {
+            WriteLineColored("  ── Attack Paths ──", ConsoleColor.DarkGray);
+            Console.WriteLine();
+
+            var displayCount = Math.Min(report.Paths.Count, 10);
+            for (int i = 0; i < displayCount; i++)
+            {
+                var path = report.Paths[i];
+                var pathRiskColor = path.RiskLevel switch
+                {
+                    "Critical" => ConsoleColor.Red,
+                    "High" => ConsoleColor.DarkYellow,
+                    "Medium" => ConsoleColor.Yellow,
+                    "Low" => ConsoleColor.Green,
+                    _ => ConsoleColor.DarkGray
+                };
+
+                WriteColored($"  [{i + 1}] ", ConsoleColor.DarkGray);
+                WriteColored($"{path.Name}", ConsoleColor.White);
+                Console.WriteLine();
+
+                WriteColored("      Risk: ", ConsoleColor.DarkGray);
+                WriteColored($"{path.ExploitabilityScore:F0}/100 ({path.RiskLevel})", pathRiskColor);
+                WriteColored("  │  Stages: ", ConsoleColor.DarkGray);
+                WriteColored($"{path.StagesCovered}", ConsoleColor.Yellow);
+                WriteColored("  │  Steps: ", ConsoleColor.DarkGray);
+                WriteLineColored($"{path.Steps.Count}", ConsoleColor.DarkGray);
+
+                // Show chain
+                WriteColored("      ", ConsoleColor.DarkGray);
+                for (int j = 0; j < path.Steps.Count; j++)
+                {
+                    var step = path.Steps[j];
+                    var stepColor = step.Finding.Severity switch
+                    {
+                        Severity.Critical => ConsoleColor.Red,
+                        Severity.Warning => ConsoleColor.Yellow,
+                        _ => ConsoleColor.DarkGray
+                    };
+
+                    if (j > 0) WriteColored(" → ", ConsoleColor.DarkGray);
+                    WriteColored($"{step.StageName}", stepColor);
+                }
+                Console.WriteLine();
+
+                // Show step details
+                foreach (var step in path.Steps)
+                {
+                    var sevColor = step.Finding.Severity switch
+                    {
+                        Severity.Critical => ConsoleColor.Red,
+                        Severity.Warning => ConsoleColor.Yellow,
+                        _ => ConsoleColor.DarkGray
+                    };
+                    var sevLabel = step.Finding.Severity switch
+                    {
+                        Severity.Critical => "CRIT",
+                        Severity.Warning => "WARN",
+                        _ => "INFO"
+                    };
+
+                    WriteColored($"        [{sevLabel}] ", sevColor);
+                    WriteColored($"{step.StageName}: ", ConsoleColor.DarkGray);
+
+                    var title = step.Finding.Title.Length > 55
+                        ? step.Finding.Title[..52] + "..."
+                        : step.Finding.Title;
+                    WriteLineColored(title, ConsoleColor.White);
+
+                    if (step.TechniqueId != null)
+                    {
+                        WriteColored("               ", ConsoleColor.DarkGray);
+                        WriteLineColored($"MITRE: {step.TechniqueId} ({step.TechniqueName})", ConsoleColor.DarkCyan);
+                    }
+                }
+                Console.WriteLine();
+            }
+
+            if (report.Paths.Count > 10)
+            {
+                WriteLineColored($"    ... and {report.Paths.Count - 10} more path(s). Use --json for full output.", ConsoleColor.DarkGray);
+                Console.WriteLine();
+            }
+        }
+        else
+        {
+            WriteLineColored("  ✅ No multi-stage attack paths detected!", ConsoleColor.Green);
+            WriteLineColored("     Your security posture blocks kill chain progression.", ConsoleColor.DarkGray);
+            Console.WriteLine();
+        }
+
+        // Chokepoints
+        if (report.Chokepoints.Count > 0)
+        {
+            WriteLineColored("  ── Remediation Chokepoints (fix these first) ──", ConsoleColor.DarkGray);
+            Console.WriteLine();
+
+            foreach (var cp in report.Chokepoints)
+            {
+                var sevColor = cp.Finding.Severity switch
+                {
+                    Severity.Critical => ConsoleColor.Red,
+                    Severity.Warning => ConsoleColor.Yellow,
+                    _ => ConsoleColor.DarkGray
+                };
+
+                WriteColored($"  #{cp.Priority} ", ConsoleColor.White);
+                var title = cp.Finding.Title.Length > 50
+                    ? cp.Finding.Title[..47] + "..."
+                    : cp.Finding.Title;
+                WriteColored(title, sevColor);
+                Console.WriteLine();
+
+                WriteColored("     ", ConsoleColor.DarkGray);
+                WriteColored($"Appears in {cp.PathCount} path(s)", ConsoleColor.DarkGray);
+                WriteColored("  │  Risk reduced: ", ConsoleColor.DarkGray);
+                WriteColored($"{cp.TotalRiskReduced:F0}", ConsoleColor.Yellow);
+                WriteColored("  │  Module: ", ConsoleColor.DarkGray);
+                WriteLineColored(cp.Module, ConsoleColor.DarkGray);
+
+                if (cp.Finding.Remediation != null)
+                {
+                    WriteColored("     Fix: ", ConsoleColor.DarkGray);
+                    var rem = cp.Finding.Remediation.Length > 70
+                        ? cp.Finding.Remediation[..67] + "..."
+                        : cp.Finding.Remediation;
+                    WriteLineColored(rem, ConsoleColor.Cyan);
+                }
+            }
+            Console.WriteLine();
+        }
+
+        // Summary
+        WriteLineColored("  ── Summary ──", ConsoleColor.DarkGray);
+        Console.WriteLine();
+        WriteColored("  ", ConsoleColor.DarkGray);
+        WriteLineColored(report.Summary, ConsoleColor.White);
+        Console.WriteLine();
+    }
+}

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -280,6 +280,7 @@ public static partial class ConsoleFormatter
         WriteHelpEntry("    --harden             ", "Generate reviewable PowerShell hardening script");
         WriteHelpEntry("    --policy <action>    ", "Security Policy as Code (export/import/validate/diff)");
         WriteHelpEntry("    --threats            ", "STRIDE threat model from audit findings");
+        WriteHelpEntry("    --attack-paths       ", "Kill chain attack path analysis with chokepoints");
         WriteHelpEntry("    --help, -h           ", "Show this help message");
         WriteHelpEntry("    --version, -v        ", "Show version information");
         Console.WriteLine();

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -41,6 +41,7 @@ return options.Command switch
     CliCommand.Threats => await HandleThreats(options),
     CliCommand.ScheduleOptimize => HandleScheduleOptimize(options),
     CliCommand.Digest => await HandleDigest(options),
+    CliCommand.AttackPaths => await HandleAttackPaths(options),
     _ => HandleHelp()
 };
 
@@ -2465,6 +2466,74 @@ static async Task<int> HandleDigest(CliOptions options)
     }
 
     // Save this run to history
+    historyService.SaveAuditResult(report);
+
+    return 0;
+}
+
+// ── Attack Path Analyzer ─────────────────────────────────────────
+
+static async Task<int> HandleAttackPaths(CliOptions options)
+{
+    var engine = BuildEngine(options.ModulesFilter);
+    var sw = Stopwatch.StartNew();
+
+    if (!options.Quiet)
+    {
+        ConsoleFormatter.PrintBanner();
+        Console.WriteLine("  Running audit for attack path analysis...");
+        Console.WriteLine();
+    }
+
+    var progress = options.Quiet
+        ? null
+        : new Progress<(string module, int current, int total)>(p =>
+            ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
+
+    var report = await engine.RunFullAuditAsync(progress);
+    sw.Stop();
+
+    if (!options.Quiet)
+    {
+        ConsoleFormatter.PrintProgressDone(engine.Modules.Count, sw.Elapsed);
+    }
+
+    // MITRE mapping first
+    var mitreMapper = new MitreAttackMapper();
+    var attackReport = mitreMapper.Analyze(report);
+
+    // Attack path analysis
+    var pathAnalyzer = new AttackPathAnalyzer();
+    var pathReport = pathAnalyzer.Analyze(report, attackReport);
+
+    if (options.Json)
+    {
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() },
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+        var json = JsonSerializer.Serialize(pathReport, jsonOptions);
+
+        if (!string.IsNullOrWhiteSpace(options.OutputFile))
+        {
+            await File.WriteAllTextAsync(options.OutputFile, json);
+            if (!options.Quiet)
+                Console.WriteLine($"  Attack path report saved to {options.OutputFile}");
+        }
+        else
+        {
+            Console.WriteLine(json);
+        }
+    }
+    else
+    {
+        ConsoleFormatter.PrintAttackPaths(pathReport);
+    }
+
+    // Save this run to history
+    using var historyService = new AuditHistoryService();
     historyService.SaveAuditResult(report);
 
     return 0;

--- a/src/WinSentinel.Core/Services/AttackPathAnalyzer.cs
+++ b/src/WinSentinel.Core/Services/AttackPathAnalyzer.cs
@@ -1,0 +1,565 @@
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+/// <summary>
+/// Chains audit findings into multi-step attack paths that model how an
+/// attacker could traverse the MITRE ATT&amp;CK kill chain on this system.
+///
+/// <para>Where <see cref="MitreAttackMapper"/> maps individual findings to
+/// ATT&amp;CK techniques, this analyzer connects those techniques into
+/// realistic attack <em>paths</em> — ordered sequences of stages an
+/// adversary would follow (Initial Access → Execution → Persistence →
+/// Privilege Escalation → Lateral Movement → Exfiltration).</para>
+///
+/// <para>Each path is scored by likelihood and impact, and the analyzer
+/// identifies <strong>chokepoint findings</strong> — the findings whose
+/// remediation would break the most attack paths.</para>
+///
+/// <h3>Usage:</h3>
+/// <code>
+/// var mapper = new MitreAttackMapper();
+/// var attackReport = mapper.Analyze(securityReport);
+/// var pathAnalyzer = new AttackPathAnalyzer();
+/// var result = pathAnalyzer.Analyze(securityReport, attackReport);
+/// Console.WriteLine(result.Summary);
+/// </code>
+/// </summary>
+public class AttackPathAnalyzer
+{
+    // ── Attack stage definitions ─────────────────────────────────
+
+    /// <summary>
+    /// Canonical stages of a kill chain attack path, ordered by progression.
+    /// </summary>
+    public enum AttackStage
+    {
+        InitialAccess = 0,
+        Execution = 1,
+        Persistence = 2,
+        PrivilegeEscalation = 3,
+        LateralMovement = 4,
+        Exfiltration = 5
+    }
+
+    /// <summary>
+    /// Maps MITRE ATT&amp;CK tactics to canonical attack stages.
+    /// Multiple tactics may map to the same stage.
+    /// </summary>
+    private static readonly Dictionary<AttackTactic, AttackStage> TacticToStage = new()
+    {
+        [AttackTactic.InitialAccess] = AttackStage.InitialAccess,
+        [AttackTactic.Reconnaissance] = AttackStage.InitialAccess,
+        [AttackTactic.Execution] = AttackStage.Execution,
+        [AttackTactic.CommandAndControl] = AttackStage.Execution,
+        [AttackTactic.Persistence] = AttackStage.Persistence,
+        [AttackTactic.DefenseEvasion] = AttackStage.Persistence,
+        [AttackTactic.PrivilegeEscalation] = AttackStage.PrivilegeEscalation,
+        [AttackTactic.CredentialAccess] = AttackStage.PrivilegeEscalation,
+        [AttackTactic.Discovery] = AttackStage.LateralMovement,
+        [AttackTactic.LateralMovement] = AttackStage.LateralMovement,
+        [AttackTactic.Collection] = AttackStage.Exfiltration,
+        [AttackTactic.Exfiltration] = AttackStage.Exfiltration,
+        [AttackTactic.Impact] = AttackStage.Exfiltration,
+    };
+
+    /// <summary>Stage display names.</summary>
+    private static readonly Dictionary<AttackStage, string> StageNames = new()
+    {
+        [AttackStage.InitialAccess] = "Initial Access",
+        [AttackStage.Execution] = "Execution",
+        [AttackStage.Persistence] = "Persistence",
+        [AttackStage.PrivilegeEscalation] = "Privilege Escalation",
+        [AttackStage.LateralMovement] = "Lateral Movement",
+        [AttackStage.Exfiltration] = "Exfiltration",
+    };
+
+    // ── Category → stage mapping (finding-level, no MITRE needed) ──
+
+    /// <summary>
+    /// Maps finding categories to attack stages for findings that may not
+    /// have a MITRE mapping. This catches common audit categories.
+    /// </summary>
+    private static readonly Dictionary<string, AttackStage> CategoryStageMap =
+        new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Initial Access
+        ["Firewall"] = AttackStage.InitialAccess,
+        ["Network"] = AttackStage.InitialAccess,
+        ["WiFi"] = AttackStage.InitialAccess,
+        ["RemoteAccess"] = AttackStage.InitialAccess,
+        ["RDP"] = AttackStage.InitialAccess,
+        ["Bluetooth"] = AttackStage.InitialAccess,
+        ["SMB"] = AttackStage.InitialAccess,
+        // Execution
+        ["PowerShell"] = AttackStage.Execution,
+        ["Application"] = AttackStage.Execution,
+        ["Browser"] = AttackStage.Execution,
+        ["Drivers"] = AttackStage.Execution,
+        // Persistence
+        ["Startup"] = AttackStage.Persistence,
+        ["ScheduledTasks"] = AttackStage.Persistence,
+        ["Services"] = AttackStage.Persistence,
+        ["Registry"] = AttackStage.Persistence,
+        // Privilege Escalation
+        ["Accounts"] = AttackStage.PrivilegeEscalation,
+        ["Credentials"] = AttackStage.PrivilegeEscalation,
+        ["Certificate"] = AttackStage.PrivilegeEscalation,
+        ["GroupPolicy"] = AttackStage.PrivilegeEscalation,
+        // Lateral Movement
+        ["DNS"] = AttackStage.LateralMovement,
+        ["WinRM"] = AttackStage.LateralMovement,
+        // Exfiltration
+        ["Privacy"] = AttackStage.Exfiltration,
+        ["Encryption"] = AttackStage.Exfiltration,
+        ["Backup"] = AttackStage.Exfiltration,
+    };
+
+    // ── Result models ────────────────────────────────────────────
+
+    /// <summary>
+    /// A single step in an attack path, backed by a real finding.
+    /// </summary>
+    public class AttackStep
+    {
+        /// <summary>Attack stage this step belongs to.</summary>
+        public required AttackStage Stage { get; init; }
+
+        /// <summary>Human-readable stage name.</summary>
+        public string StageName => StageNames.GetValueOrDefault(Stage, Stage.ToString());
+
+        /// <summary>The finding that enables this step.</summary>
+        public required Finding Finding { get; init; }
+
+        /// <summary>MITRE technique ID (if mapped).</summary>
+        public string? TechniqueId { get; init; }
+
+        /// <summary>MITRE technique name (if mapped).</summary>
+        public string? TechniqueName { get; init; }
+
+        /// <summary>Source audit module.</summary>
+        public required string Module { get; init; }
+    }
+
+    /// <summary>
+    /// A complete multi-step attack path from initial access to objective.
+    /// </summary>
+    public class AttackPath
+    {
+        /// <summary>Ordered steps in this path.</summary>
+        public List<AttackStep> Steps { get; init; } = new();
+
+        /// <summary>Path name describing the scenario.</summary>
+        public required string Name { get; init; }
+
+        /// <summary>Brief description of the attack scenario.</summary>
+        public required string Description { get; init; }
+
+        /// <summary>Number of distinct stages covered.</summary>
+        public int StagesCovered => Steps.Select(s => s.Stage).Distinct().Count();
+
+        /// <summary>
+        /// Exploitability score (0–100). Longer paths that span more stages
+        /// with higher-severity findings score higher.
+        /// </summary>
+        public double ExploitabilityScore { get; set; }
+
+        /// <summary>Risk level derived from exploitability score.</summary>
+        public string RiskLevel => ExploitabilityScore switch
+        {
+            >= 80 => "Critical",
+            >= 60 => "High",
+            >= 40 => "Medium",
+            >= 20 => "Low",
+            _ => "Minimal"
+        };
+
+        /// <summary>Highest severity among all steps.</summary>
+        public Severity HighestSeverity =>
+            Steps.Count > 0 ? Steps.Max(s => s.Finding.Severity) : Severity.Pass;
+    }
+
+    /// <summary>
+    /// A finding that appears in multiple attack paths — a remediation
+    /// chokepoint. Fixing it breaks the most paths.
+    /// </summary>
+    public class Chokepoint
+    {
+        /// <summary>The finding.</summary>
+        public required Finding Finding { get; init; }
+
+        /// <summary>Source module.</summary>
+        public required string Module { get; init; }
+
+        /// <summary>How many attack paths this finding appears in.</summary>
+        public int PathCount { get; set; }
+
+        /// <summary>Sum of exploitability scores of paths it appears in.</summary>
+        public double TotalRiskReduced { get; set; }
+
+        /// <summary>Priority rank (1 = fix first).</summary>
+        public int Priority { get; set; }
+    }
+
+    /// <summary>
+    /// Full attack path analysis result.
+    /// </summary>
+    public class AttackPathReport
+    {
+        public DateTimeOffset GeneratedAt { get; init; } = DateTimeOffset.UtcNow;
+
+        /// <summary>All discovered attack paths, sorted by exploitability (descending).</summary>
+        public List<AttackPath> Paths { get; init; } = new();
+
+        /// <summary>Top chokepoints — fix these to break the most paths.</summary>
+        public List<Chokepoint> Chokepoints { get; init; } = new();
+
+        /// <summary>Per-stage finding counts.</summary>
+        public Dictionary<string, int> StageBreakdown { get; init; } = new();
+
+        /// <summary>Total findings analysed.</summary>
+        public int TotalFindings { get; set; }
+
+        /// <summary>Total findings that contributed to at least one path.</summary>
+        public int FindingsInPaths { get; set; }
+
+        /// <summary>Highest exploitability score across all paths.</summary>
+        public double MaxExploitability =>
+            Paths.Count > 0 ? Paths.Max(p => p.ExploitabilityScore) : 0;
+
+        /// <summary>Overall risk level.</summary>
+        public string OverallRisk => MaxExploitability switch
+        {
+            >= 80 => "Critical",
+            >= 60 => "High",
+            >= 40 => "Medium",
+            >= 20 => "Low",
+            _ => "Minimal"
+        };
+
+        /// <summary>Human-readable summary.</summary>
+        public string Summary
+        {
+            get
+            {
+                if (Paths.Count == 0)
+                    return "No multi-stage attack paths detected. Your security posture blocks kill chain progression.";
+
+                var critical = Paths.Count(p => p.RiskLevel == "Critical");
+                var high = Paths.Count(p => p.RiskLevel == "High");
+                return $"Detected {Paths.Count} attack path(s) ({critical} critical, {high} high risk). " +
+                       $"Top chokepoint: \"{Chokepoints.FirstOrDefault()?.Finding.Title ?? "none"}\" " +
+                       $"(appears in {Chokepoints.FirstOrDefault()?.PathCount ?? 0} path(s)). " +
+                       $"Overall risk: {OverallRisk}.";
+            }
+        }
+    }
+
+    // ── Analysis ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Analyse a security report and its MITRE mapping to discover attack paths.
+    /// </summary>
+    /// <param name="report">The security audit report.</param>
+    /// <param name="attackReport">
+    /// Optional MITRE ATT&amp;CK mapping report. If null, findings are
+    /// classified by category alone.
+    /// </param>
+    /// <returns>Attack path analysis report.</returns>
+    public AttackPathReport Analyze(SecurityReport report, AttackReport? attackReport = null)
+    {
+        // 1. Classify all actionable findings into attack stages
+        var stageFindings = ClassifyFindings(report, attackReport);
+
+        // 2. Build attack paths by chaining stages
+        var paths = BuildPaths(stageFindings);
+
+        // 3. Score each path
+        foreach (var path in paths) ScorePath(path);
+        paths.Sort((a, b) => b.ExploitabilityScore.CompareTo(a.ExploitabilityScore));
+
+        // 4. Identify chokepoints
+        var chokepoints = FindChokepoints(paths);
+
+        // 5. Stage breakdown
+        var breakdown = new Dictionary<string, int>();
+        foreach (var stage in Enum.GetValues<AttackStage>())
+        {
+            var name = StageNames.GetValueOrDefault(stage, stage.ToString());
+            breakdown[name] = stageFindings.GetValueOrDefault(stage)?.Count ?? 0;
+        }
+
+        var findingsInPaths = paths
+            .SelectMany(p => p.Steps)
+            .Select(s => s.Finding.Title)
+            .Distinct()
+            .Count();
+
+        return new AttackPathReport
+        {
+            Paths = paths,
+            Chokepoints = chokepoints,
+            StageBreakdown = breakdown,
+            TotalFindings = report.TotalFindings,
+            FindingsInPaths = findingsInPaths,
+        };
+    }
+
+    // ── Stage classification ─────────────────────────────────────
+
+    private Dictionary<AttackStage, List<AttackStep>> ClassifyFindings(
+        SecurityReport report, AttackReport? attackReport)
+    {
+        var result = new Dictionary<AttackStage, List<AttackStep>>();
+
+        // Build a lookup from finding title → technique for MITRE-mapped findings
+        var mitreLookup = new Dictionary<string, (string Id, string Name, AttackTactic Tactic)>(
+            StringComparer.OrdinalIgnoreCase);
+
+        if (attackReport != null)
+        {
+            foreach (var tactic in attackReport.TacticExposures)
+            foreach (var tech in tactic.Techniques)
+            {
+                // The technique summary doesn't carry individual finding titles,
+                // so we rely on tactic-level mapping as a hint.
+                // We'll match by tactic when a finding's category matches.
+            }
+        }
+
+        foreach (var auditResult in report.Results)
+        foreach (var finding in auditResult.Findings)
+        {
+            // Skip passed/info findings — they're not exploitable
+            if (finding.Severity < Severity.Warning) continue;
+
+            AttackStage? stage = null;
+            string? techId = null;
+            string? techName = null;
+
+            // Try MITRE tactic → stage mapping if attack report is available
+            if (attackReport != null)
+            {
+                foreach (var tacticExposure in attackReport.TacticExposures)
+                {
+                    if (TacticToStage.TryGetValue(tacticExposure.Tactic, out var mappedStage))
+                    {
+                        // Check if this finding's category matches any technique in this tactic
+                        foreach (var tech in tacticExposure.Techniques)
+                        {
+                            if (CategoryMatchesTechnique(auditResult.Category, finding, tech))
+                            {
+                                stage = mappedStage;
+                                techId = tech.TechniqueId;
+                                techName = tech.TechniqueName;
+                                break;
+                            }
+                        }
+                    }
+                    if (stage.HasValue) break;
+                }
+            }
+
+            // Fallback: category → stage mapping
+            if (!stage.HasValue && CategoryStageMap.TryGetValue(auditResult.Category, out var catStage))
+            {
+                stage = catStage;
+            }
+
+            // Also try finding's own category field
+            if (!stage.HasValue && !string.IsNullOrEmpty(finding.Category) &&
+                CategoryStageMap.TryGetValue(finding.Category, out var findCatStage))
+            {
+                stage = findCatStage;
+            }
+
+            if (!stage.HasValue) continue; // Can't classify — skip
+
+            if (!result.ContainsKey(stage.Value))
+                result[stage.Value] = new List<AttackStep>();
+
+            result[stage.Value].Add(new AttackStep
+            {
+                Stage = stage.Value,
+                Finding = finding,
+                TechniqueId = techId,
+                TechniqueName = techName,
+                Module = auditResult.ModuleName,
+            });
+        }
+
+        return result;
+    }
+
+    private static bool CategoryMatchesTechnique(string category, Finding finding, TechniqueSummary tech)
+    {
+        // Match by category or finding title containing part of technique name
+        var techLower = tech.TechniqueName.ToLowerInvariant();
+        var catLower = category.ToLowerInvariant();
+        var titleLower = finding.Title.ToLowerInvariant();
+
+        // Direct substring matches
+        if (techLower.Contains(catLower) || catLower.Contains(techLower)) return true;
+
+        // Split technique name into words and check if any appear in the title
+        var techWords = techLower.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        int matches = techWords.Count(w => w.Length > 3 && titleLower.Contains(w));
+        return matches >= 2; // At least 2 significant words match
+    }
+
+    // ── Path building ────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds attack paths by combining findings across consecutive stages.
+    /// A valid path needs at least 2 stages. Paths are built greedily:
+    /// for each initial-access finding, extend through subsequent stages.
+    /// </summary>
+    private static List<AttackPath> BuildPaths(Dictionary<AttackStage, List<AttackStep>> stageFindings)
+    {
+        var paths = new List<AttackPath>();
+        var stages = Enum.GetValues<AttackStage>().OrderBy(s => (int)s).ToArray();
+
+        // Find the earliest populated stage
+        int startIdx = -1;
+        for (int i = 0; i < stages.Length; i++)
+        {
+            if (stageFindings.ContainsKey(stages[i]) && stageFindings[stages[i]].Count > 0)
+            {
+                startIdx = i;
+                break;
+            }
+        }
+
+        if (startIdx < 0) return paths;
+
+        var entrySteps = stageFindings[stages[startIdx]];
+
+        // For each entry point, try to build the longest path
+        foreach (var entry in entrySteps)
+        {
+            var pathSteps = new List<AttackStep> { entry };
+
+            // Greedily extend to subsequent stages
+            for (int i = startIdx + 1; i < stages.Length; i++)
+            {
+                if (!stageFindings.TryGetValue(stages[i], out var candidates) ||
+                    candidates.Count == 0)
+                    continue;
+
+                // Pick the highest-severity finding at this stage
+                var best = candidates
+                    .OrderByDescending(s => s.Finding.Severity)
+                    .ThenByDescending(s => s.TechniqueId != null ? 1 : 0)
+                    .First();
+
+                pathSteps.Add(best);
+            }
+
+            // Only keep paths with ≥ 2 distinct stages
+            if (pathSteps.Select(s => s.Stage).Distinct().Count() < 2) continue;
+
+            var (name, desc) = GeneratePathNarrative(pathSteps);
+
+            paths.Add(new AttackPath
+            {
+                Name = name,
+                Description = desc,
+                Steps = pathSteps,
+            });
+        }
+
+        // Deduplicate paths with identical step titles
+        var seen = new HashSet<string>();
+        var deduped = new List<AttackPath>();
+        foreach (var path in paths)
+        {
+            var key = string.Join("|", path.Steps.Select(s => s.Finding.Title));
+            if (seen.Add(key)) deduped.Add(path);
+        }
+
+        return deduped;
+    }
+
+    private static (string Name, string Description) GeneratePathNarrative(List<AttackStep> steps)
+    {
+        var entry = steps[0];
+        var final = steps[^1];
+
+        var name = $"{entry.StageName} via {Shorten(entry.Finding.Title)} → {final.StageName}";
+
+        var stageNames = steps.Select(s => s.StageName).Distinct();
+        var desc = $"Attacker chains {steps.Count} step(s) across {string.Join(" → ", stageNames)}. " +
+                   $"Entry: {entry.Finding.Title}. " +
+                   $"Objective: {final.Finding.Title}.";
+
+        return (name, desc);
+    }
+
+    private static string Shorten(string text) =>
+        text.Length <= 40 ? text : text[..37] + "...";
+
+    // ── Scoring ──────────────────────────────────────────────────
+
+    private static void ScorePath(AttackPath path)
+    {
+        if (path.Steps.Count == 0) { path.ExploitabilityScore = 0; return; }
+
+        // Factors:
+        // 1. Stage coverage (more stages = more dangerous) — 40% weight
+        double stageCoverage = path.StagesCovered / 6.0;
+
+        // 2. Average severity of steps — 35% weight
+        double avgSeverity = path.Steps.Average(s => (int)s.Finding.Severity) / 3.0;
+
+        // 3. Has critical findings — 15% weight
+        double hasCritical = path.Steps.Any(s => s.Finding.Severity == Severity.Critical) ? 1.0 : 0.0;
+
+        // 4. Path length bonus (longer paths = more complete attack) — 10% weight
+        double lengthBonus = Math.Min(path.Steps.Count / 6.0, 1.0);
+
+        path.ExploitabilityScore = Math.Round(
+            (stageCoverage * 0.40 + avgSeverity * 0.35 + hasCritical * 0.15 + lengthBonus * 0.10) * 100,
+            1);
+    }
+
+    // ── Chokepoint analysis ──────────────────────────────────────
+
+    private static List<Chokepoint> FindChokepoints(List<AttackPath> paths)
+    {
+        // Count how many paths each finding appears in
+        var findingPaths = new Dictionary<string, (Finding Finding, string Module, double TotalRisk, int Count)>(
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in paths)
+        foreach (var step in path.Steps)
+        {
+            var key = step.Finding.Title;
+            if (findingPaths.TryGetValue(key, out var existing))
+            {
+                findingPaths[key] = (existing.Finding, existing.Module,
+                    existing.TotalRisk + path.ExploitabilityScore, existing.Count + 1);
+            }
+            else
+            {
+                findingPaths[key] = (step.Finding, step.Module, path.ExploitabilityScore, 1);
+            }
+        }
+
+        var chokepoints = findingPaths.Values
+            .Where(f => f.Count >= 1)
+            .OrderByDescending(f => f.TotalRisk)
+            .ThenByDescending(f => f.Count)
+            .Select((f, i) => new Chokepoint
+            {
+                Finding = f.Finding,
+                Module = f.Module,
+                PathCount = f.Count,
+                TotalRiskReduced = Math.Round(f.TotalRisk, 1),
+                Priority = i + 1,
+            })
+            .Take(10)
+            .ToList();
+
+        return chokepoints;
+    }
+}

--- a/tests/WinSentinel.Tests/Services/AttackPathAnalyzerTests.cs
+++ b/tests/WinSentinel.Tests/Services/AttackPathAnalyzerTests.cs
@@ -1,0 +1,267 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+using Xunit;
+
+namespace WinSentinel.Tests.Services;
+
+public class AttackPathAnalyzerTests
+{
+    private static SecurityReport BuildReport(params (string module, string category, Finding finding)[] entries)
+    {
+        var groups = entries.GroupBy(e => (e.module, e.category));
+        var results = groups.Select(g => new AuditResult
+        {
+            ModuleName = g.Key.module,
+            Category = g.Key.category,
+            Findings = g.Select(e => e.finding).ToList(),
+            StartTime = DateTimeOffset.UtcNow,
+            EndTime = DateTimeOffset.UtcNow,
+        }).ToList();
+
+        return new SecurityReport
+        {
+            Results = results,
+            SecurityScore = 50,
+        };
+    }
+
+    [Fact]
+    public void Analyze_EmptyReport_ReturnsNoPaths()
+    {
+        var analyzer = new AttackPathAnalyzer();
+        var report = new SecurityReport();
+        var result = analyzer.Analyze(report);
+
+        Assert.Empty(result.Paths);
+        Assert.Empty(result.Chokepoints);
+        Assert.Equal(0, result.TotalFindings);
+        Assert.Equal("Minimal", result.OverallRisk);
+    }
+
+    [Fact]
+    public void Analyze_SingleStage_NoPaths()
+    {
+        // Only firewall findings (Initial Access) — no path without a second stage
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Warning("Open port 3389", "RDP port exposed", "Firewall")),
+            ("FirewallAudit", "Firewall", Finding.Critical("No firewall rules", "Default allow all", "Firewall"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.Empty(result.Paths);
+        Assert.Contains("Initial Access", result.StageBreakdown.Keys);
+    }
+
+    [Fact]
+    public void Analyze_TwoStages_CreatesPath()
+    {
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Warning("Open port 3389", "RDP port exposed", "Firewall")),
+            ("AccountAudit", "Accounts", Finding.Critical("Admin no MFA", "MFA not enabled for admin", "Accounts"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.NotEmpty(result.Paths);
+        Assert.True(result.Paths[0].StagesCovered >= 2);
+        Assert.True(result.Paths[0].ExploitabilityScore > 0);
+    }
+
+    [Fact]
+    public void Analyze_FullKillChain_HighScore()
+    {
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Critical("Open port 3389", "RDP exposed", "Firewall")),
+            ("PowerShellAudit", "PowerShell", Finding.Warning("Unrestricted execution", "No execution policy", "PowerShell")),
+            ("StartupAudit", "Startup", Finding.Warning("Unknown startup item", "Suspicious startup", "Startup")),
+            ("AccountAudit", "Accounts", Finding.Critical("Admin no password", "Blank admin password", "Accounts")),
+            ("NetworkAudit", "DNS", Finding.Warning("DNS over plaintext", "No DoH/DoT", "DNS")),
+            ("PrivacyAudit", "Privacy", Finding.Critical("Clipboard monitoring", "Data leak risk", "Privacy"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.NotEmpty(result.Paths);
+        var topPath = result.Paths[0];
+        Assert.True(topPath.StagesCovered >= 4, $"Expected ≥4 stages, got {topPath.StagesCovered}");
+        Assert.True(topPath.ExploitabilityScore >= 50, $"Expected score ≥50, got {topPath.ExploitabilityScore}");
+        Assert.True(result.OverallRisk is "Critical" or "High",
+            $"Expected Critical or High risk, got {result.OverallRisk}");
+    }
+
+    [Fact]
+    public void Analyze_ChokePoints_IdentifiesMostCommon()
+    {
+        // Create findings that appear across multiple stages
+        var firewallFinding = Finding.Critical("Open port 3389", "RDP exposed", "Firewall");
+        var accountFinding = Finding.Critical("Admin no MFA", "No MFA", "Accounts");
+
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", firewallFinding),
+            ("FirewallAudit", "Firewall", Finding.Warning("Open port 22", "SSH exposed", "Firewall")),
+            ("AccountAudit", "Accounts", accountFinding),
+            ("StartupAudit", "Startup", Finding.Warning("Persistence item", "Unknown startup", "Startup"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.NotEmpty(result.Chokepoints);
+        Assert.Equal(1, result.Chokepoints[0].Priority);
+        Assert.True(result.Chokepoints[0].TotalRiskReduced > 0);
+    }
+
+    [Fact]
+    public void Analyze_PassFindings_Ignored()
+    {
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Pass("Firewall enabled", "Good", "Firewall")),
+            ("AccountAudit", "Accounts", Finding.Pass("MFA enabled", "Good", "Accounts"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.Empty(result.Paths);
+        Assert.Equal(0, result.FindingsInPaths);
+    }
+
+    [Fact]
+    public void Analyze_InfoFindings_Ignored()
+    {
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Info("5 rules configured", "Details", "Firewall")),
+            ("AccountAudit", "Accounts", Finding.Info("3 users found", "Details", "Accounts"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.Empty(result.Paths);
+    }
+
+    [Fact]
+    public void Analyze_StageBreakdown_AllStagesPresent()
+    {
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Warning("Open port", "Exposed", "Firewall"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.Equal(6, result.StageBreakdown.Count);
+        Assert.Contains("Initial Access", result.StageBreakdown.Keys);
+        Assert.Contains("Execution", result.StageBreakdown.Keys);
+        Assert.Contains("Persistence", result.StageBreakdown.Keys);
+        Assert.Contains("Privilege Escalation", result.StageBreakdown.Keys);
+        Assert.Contains("Lateral Movement", result.StageBreakdown.Keys);
+        Assert.Contains("Exfiltration", result.StageBreakdown.Keys);
+    }
+
+    [Fact]
+    public void Analyze_WithMitreReport_UsesMapping()
+    {
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Warning("Open port 3389", "RDP exposed", "Firewall")),
+            ("PowerShellAudit", "PowerShell", Finding.Warning("Unrestricted execution policy", "Exec bypass", "PowerShell")),
+            ("AccountAudit", "Accounts", Finding.Critical("Weak passwords", "No complexity", "Accounts")),
+            ("PrivacyAudit", "Privacy", Finding.Warning("Clipboard access", "Data leak", "Privacy"))
+        );
+
+        // Create a MITRE attack report
+        var mapper = new MitreAttackMapper();
+        var attackReport = mapper.Analyze(report);
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report, attackReport);
+
+        // With 4 stages covered, should find paths
+        Assert.NotEmpty(result.Paths);
+    }
+
+    [Fact]
+    public void AttackPath_RiskLevel_CorrectClassification()
+    {
+        var path = new AttackPathAnalyzer.AttackPath
+        {
+            Name = "Test",
+            Description = "Test path",
+        };
+
+        path.ExploitabilityScore = 85;
+        Assert.Equal("Critical", path.RiskLevel);
+
+        path.ExploitabilityScore = 65;
+        Assert.Equal("High", path.RiskLevel);
+
+        path.ExploitabilityScore = 45;
+        Assert.Equal("Medium", path.RiskLevel);
+
+        path.ExploitabilityScore = 25;
+        Assert.Equal("Low", path.RiskLevel);
+
+        path.ExploitabilityScore = 10;
+        Assert.Equal("Minimal", path.RiskLevel);
+    }
+
+    [Fact]
+    public void AttackPathReport_Summary_DescriptiveWhenPaths()
+    {
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Critical("Open RDP", "Port 3389", "Firewall")),
+            ("AccountAudit", "Accounts", Finding.Warning("Weak pass", "No complexity", "Accounts"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        Assert.NotEmpty(result.Summary);
+        Assert.Contains("attack path", result.Summary);
+    }
+
+    [Fact]
+    public void AttackPathReport_Summary_DescriptiveWhenNoPaths()
+    {
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(new SecurityReport());
+
+        Assert.Contains("No multi-stage", result.Summary);
+    }
+
+    [Fact]
+    public void AttackStep_StageName_Correct()
+    {
+        var step = new AttackPathAnalyzer.AttackStep
+        {
+            Stage = AttackPathAnalyzer.AttackStage.InitialAccess,
+            Finding = Finding.Warning("Test", "Test", "Test"),
+            Module = "TestModule",
+        };
+
+        Assert.Equal("Initial Access", step.StageName);
+    }
+
+    [Fact]
+    public void Analyze_DuplicatePaths_Deduplicated()
+    {
+        // Two identical firewall findings should produce deduplicated paths
+        var report = BuildReport(
+            ("FirewallAudit", "Firewall", Finding.Warning("Open port 3389", "RDP", "Firewall")),
+            ("FirewallAudit", "Firewall", Finding.Warning("Open port 3389", "RDP", "Firewall")),
+            ("AccountAudit", "Accounts", Finding.Warning("Weak pass", "No complexity", "Accounts"))
+        );
+
+        var analyzer = new AttackPathAnalyzer();
+        var result = analyzer.Analyze(report);
+
+        // Should not have duplicate paths with identical step titles
+        var pathKeys = result.Paths.Select(p =>
+            string.Join("|", p.Steps.Select(s => s.Finding.Title))).ToList();
+        Assert.Equal(pathKeys.Distinct().Count(), pathKeys.Count);
+    }
+}


### PR DESCRIPTION
Adds **AttackPathAnalyzer** — chains audit findings into multi-step attack paths following the MITRE ATT&CK kill chain.

**Features:**
- 🔗 Chains findings across 6 attack stages (Initial Access → Exfiltration)
- ⚔️ Builds realistic attack scenarios
- 📊 Scores each path by exploitability
- 🎯 Identifies remediation chokepoints (fix these first)
- 🗺️ Integrates with MitreAttackMapper

**CLI:** \winsentinel --attack-paths [--json] [-o file]\

**Files:** AttackPathAnalyzer.cs (565 lines), ConsoleFormatter.AttackPaths.cs, 14 unit tests (all passing)