### PR TITLE
fix: ThreatCorrelator race conditions and duplicate correlations

### DIFF
--- a/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
+++ b/src/WinSentinel.Agent/Services/ThreatCorrelator.cs
@@ -62,12 +62,12 @@ public class ThreatCorrelator
     public List<CorrelatedThreat> ProcessEvent(ThreatEvent newEvent)
     {
         _eventWindow.Enqueue(newEvent);
-        TrimWindow();
 
         var correlations = new List<CorrelatedThreat>();
 
         lock (_correlationLock)
         {
+            TrimWindow();
             var windowEvents = _eventWindow.ToList();
 
             // Run all correlation rules
@@ -96,8 +96,11 @@ public class ThreatCorrelator
     /// </summary>
     public List<ThreatEvent> GetWindowEvents()
     {
-        TrimWindow();
-        return _eventWindow.ToList();
+        lock (_correlationLock)
+        {
+            TrimWindow();
+            return _eventWindow.ToList();
+        }
     }
 
     /// <summary>
@@ -231,18 +234,14 @@ public class ThreatCorrelator
             suspiciousProcess &&
             !IsRecentCorrelation("DefenderPlusUnsigned", "reverse"))
         {
-            var processEvent = window.First(e =>
-                e.Source == "ProcessMonitor" &&
-                e.Severity >= ThreatSeverity.Medium);
-
             results.Add(new CorrelatedThreat
             {
-                ContributingEvents = { newEvent, processEvent },
+                ContributingEvents = { newEvent, suspiciousProcessEvent! },
                 CombinedSeverity = ThreatSeverity.Critical,
                 RuleName = "DefenderPlusUnsigned",
                 ChainDescription = $"Windows Defender was just disabled while suspicious processes are running. " +
-                                   $"Process: {processEvent.Title}. Immediate investigation required.",
-                ThreatScore = CalculateChainScore(newEvent, processEvent) + 50
+                                   $"Process: {suspiciousProcessEvent!.Title}. Immediate investigation required.",
+                ThreatScore = CalculateChainScore(newEvent, suspiciousProcessEvent!) + 50
             });
         }
     }
@@ -345,22 +344,35 @@ public class ThreatCorrelator
     /// </summary>
     internal void CheckRapidMultiModule(ThreatEvent newEvent, List<ThreatEvent> window, List<CorrelatedThreat> results)
     {
-        // Only check for medium+ severity events
+        // Only consider medium+ severity events
+        if (newEvent.Severity < ThreatSeverity.Medium) return;
+
         var significantEvents = window.Where(e => e.Severity >= ThreatSeverity.Medium).ToList();
         var distinctSources = significantEvents.Select(e => e.Source).Distinct().ToList();
 
-        if (distinctSources.Count >= 3 && !IsRecentCorrelation("RapidMultiModule", ""))
+        // Only fire when newEvent is the event that pushed distinct source count to 3+
+        // i.e., without newEvent's source, the count would be below 3
+        if (distinctSources.Count >= 3)
         {
-            results.Add(new CorrelatedThreat
+            var sourcesWithoutNew = significantEvents
+                .Where(e => e.Id != newEvent.Id)
+                .Select(e => e.Source)
+                .Distinct()
+                .Count();
+
+            if (sourcesWithoutNew < 3 && !IsRecentCorrelation("RapidMultiModule", ""))
             {
-                ContributingEvents = significantEvents.Take(10).ToList(),
-                CombinedSeverity = ThreatSeverity.Critical,
-                RuleName = "RapidMultiModule",
-                ChainDescription = $"Coordinated attack suspected: {significantEvents.Count} significant events " +
-                                   $"detected across {distinctSources.Count} modules ({string.Join(", ", distinctSources)}) " +
-                                   $"within {CorrelationWindow.TotalMinutes} minutes.",
-                ThreatScore = significantEvents.Sum(e => SeverityScore(e.Severity)) + 20
-            });
+                results.Add(new CorrelatedThreat
+                {
+                    ContributingEvents = significantEvents.Take(10).ToList(),
+                    CombinedSeverity = ThreatSeverity.Critical,
+                    RuleName = "RapidMultiModule",
+                    ChainDescription = $"Coordinated attack suspected: {significantEvents.Count} significant events " +
+                                       $"detected across {distinctSources.Count} modules ({string.Join(", ", distinctSources)}) " +
+                                       $"within {CorrelationWindow.TotalMinutes} minutes.",
+                    ThreatScore = significantEvents.Sum(e => SeverityScore(e.Severity)) + 20
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #93

**Bug 1:** CheckDefenderPlusUnsigned second branch now uses suspiciousProcessEvent directly instead of re-querying, preventing duplicate correlations.

**Bug 2:** TrimWindow() moved inside _correlationLock for atomic trim+snapshot under concurrent access.

**Bug 3:** CheckRapidMultiModule only fires when newEvent pushes distinct source count to 3+, preventing alert floods.