### PR TITLE
security: harden ValidateFilePath against NT path and symlink bypasses

### DIFF
--- a/src/WinSentinel.Core/Helpers/InputSanitizer.cs
+++ b/src/WinSentinel.Core/Helpers/InputSanitizer.cs
@@ -146,6 +146,16 @@ public static partial class InputSanitizer
         if (trimmed.StartsWith(@"\\") || trimmed.StartsWith("//"))
             return null;
 
+        // Reject NT object manager paths (\??\, \Device\, \DosDevices\) which
+        // bypass normal path resolution and could target arbitrary volumes
+        if (trimmed.StartsWith(@"\??") || trimmed.StartsWith(@"\Device", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith(@"\DosDevices", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        // Reject forward-slash UNC variants (//?/, //./device)
+        if (trimmed.StartsWith("//?") || trimmed.StartsWith("//./"))
+            return null;
+
         // Reject path traversal sequences before canonicalization
         if (trimmed.Contains(".."))
             return null;
@@ -169,18 +179,35 @@ public static partial class InputSanitizer
         if (fullPath.Contains(".."))
             return null;
 
-        // Check against protected system directories
+        // Resolve symlinks/junctions to the real target path to prevent
+        // bypass via junction pointing into a protected directory
+        string resolvedPath;
+        try
+        {
+            // ResolveLinkTarget returns null for non-links; fall back to fullPath
+            var linkTarget = File.ResolveLinkTarget(fullPath, returnFinalTarget: true);
+            resolvedPath = linkTarget?.FullName ?? fullPath;
+        }
+        catch
+        {
+            resolvedPath = fullPath;
+        }
+
+        // Check BOTH the stated path and the resolved target against protected dirs
         foreach (var protectedDir in ProtectedDirectories)
         {
-            if (fullPath.StartsWith(protectedDir, StringComparison.OrdinalIgnoreCase))
+            if (fullPath.StartsWith(protectedDir, StringComparison.OrdinalIgnoreCase) ||
+                resolvedPath.StartsWith(protectedDir, StringComparison.OrdinalIgnoreCase))
                 return null;
         }
 
-        // Check against protected system file names
+        // Check against protected system file names (check both paths)
         var fileName = Path.GetFileName(fullPath);
+        var resolvedFileName = Path.GetFileName(resolvedPath);
         foreach (var protectedFile in ProtectedFileNames)
         {
-            if (fileName.Equals(protectedFile, StringComparison.OrdinalIgnoreCase))
+            if (fileName.Equals(protectedFile, StringComparison.OrdinalIgnoreCase) ||
+                resolvedFileName.Equals(protectedFile, StringComparison.OrdinalIgnoreCase))
                 return null;
         }
 

--- a/tests/WinSentinel.Tests/InputSanitizerTests.cs
+++ b/tests/WinSentinel.Tests/InputSanitizerTests.cs
@@ -557,6 +557,23 @@ public class InputSanitizerTests
         Assert.NotNull(result);
     }
 
+    [Fact]
+    public void ValidateFilePath_NtObjectManagerPaths_ReturnsNull()
+    {
+        // NT kernel object paths that bypass normal path resolution
+        Assert.Null(InputSanitizer.ValidateFilePath(@"\??\C:\Windows\System32\cmd.exe"));
+        Assert.Null(InputSanitizer.ValidateFilePath(@"\Device\HarddiskVolume1\file.exe"));
+        Assert.Null(InputSanitizer.ValidateFilePath(@"\DosDevices\C:\temp\file.exe"));
+    }
+
+    [Fact]
+    public void ValidateFilePath_ForwardSlashUncVariants_ReturnsNull()
+    {
+        // Forward-slash UNC variants that could bypass the backslash check
+        Assert.Null(InputSanitizer.ValidateFilePath("//?/C:/Windows/System32/cmd.exe"));
+        Assert.Null(InputSanitizer.ValidateFilePath("//./device/file.exe"));
+    }
+
     // ── SanitizeProcessInput ──────────────────────────────────────────
 
     [Theory]


### PR DESCRIPTION
## Summary

Hardens \InputSanitizer.ValidateFilePath()\ against three path bypass vectors that could allow an attacker to quarantine (effectively delete) files from protected system directories.

## Vulnerabilities Fixed

### 1. NT Object Manager Paths
Paths like \\\??\C:\Windows\System32\cmd.exe\, \\\Device\\HarddiskVolume1\\file.exe\, and \\\DosDevices\\C:\\temp\\file.exe\ bypass normal path resolution at the kernel level. The existing UNC check only caught \\\\\\ prefixes, not these NT-internal path formats.

### 2. Forward-Slash UNC Variants
\//?/C:/Windows/System32/cmd.exe\ and \//./device/file.exe\ evade the backslash-based UNC detection.

### 3. Symlink/Junction Resolution
A junction at \D:\\Temp\\escape\ pointing to \C:\\Windows\\System32\ would pass the protected-directory check (since \D:\\Temp\ is not protected), but the actual file operation would target the protected directory. Now we resolve symlinks/junctions before checking.

## Changes
- \InputSanitizer.cs\: Added NT path, forward-slash UNC, and symlink resolution checks
- \InputSanitizerTests.cs\: Added test cases for all new rejection vectors