### PR TITLE
feat: add --compliance CLI command for framework evaluation

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -74,6 +74,8 @@ public class CliOptions
     public int ScheduleOptimizeDays { get; set; } = 90;
     public int DigestHistoryDays { get; set; } = 30;
     public string DigestFormat { get; set; } = "text";
+    public string? ComplianceFramework { get; set; }
+    public bool ComplianceCrossFramework { get; set; }
 }
 
 public enum CliCommand
@@ -101,6 +103,7 @@ public enum CliCommand
     ScheduleOptimize,
     Digest,
     AttackPaths,
+    Compliance,
     Help,
     Version
 }
@@ -402,6 +405,20 @@ public static class CliParser
 
                 case "--attack-paths":
                     options.Command = CliCommand.AttackPaths;
+                    break;
+
+                case "--compliance":
+                    options.Command = CliCommand.Compliance;
+                    break;
+
+                case "--framework":
+                    if (!TryConsumeArg(args, ref i, "--framework", out var fwId, out var fwErr))
+                    { options.Error = fwErr; return options; }
+                    options.ComplianceFramework = fwId.ToLowerInvariant();
+                    break;
+
+                case "--cross-framework":
+                    options.ComplianceCrossFramework = true;
                     break;
 
                 case "--digest-days":

--- a/src/WinSentinel.Cli/ConsoleFormatter.Compliance.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Compliance.cs
@@ -1,0 +1,247 @@
+using System.Text;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Cli;
+
+public static partial class ConsoleFormatter
+{
+    /// <summary>
+    /// Print a single-framework compliance report with control-level details.
+    /// </summary>
+    public static void PrintComplianceReport(ComplianceReport report)
+    {
+        Console.WriteLine();
+        WriteLineColored($"  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+        WriteLineColored($"  ║       📋  Compliance Report                 ║", ConsoleColor.Cyan);
+        WriteLineColored($"  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        // Framework info
+        WriteColored("  Framework: ", ConsoleColor.DarkGray);
+        WriteLineColored(report.FrameworkName, ConsoleColor.White);
+        WriteColored("  Version:   ", ConsoleColor.DarkGray);
+        WriteLineColored(report.FrameworkVersion, ConsoleColor.White);
+        Console.WriteLine();
+
+        // Verdict
+        var verdictColor = report.Summary.OverallVerdict switch
+        {
+            ComplianceVerdict.Compliant => ConsoleColor.Green,
+            ComplianceVerdict.PartiallyCompliant => ConsoleColor.Yellow,
+            ComplianceVerdict.NonCompliant => ConsoleColor.Red,
+            _ => ConsoleColor.DarkGray
+        };
+        var verdictIcon = report.Summary.OverallVerdict switch
+        {
+            ComplianceVerdict.Compliant => "✅",
+            ComplianceVerdict.PartiallyCompliant => "⚠️",
+            ComplianceVerdict.NonCompliant => "❌",
+            _ => "❓"
+        };
+        WriteColored("  Verdict: ", ConsoleColor.DarkGray);
+        WriteLineColored($"{verdictIcon} {report.Summary.OverallVerdict}", verdictColor);
+
+        WriteColored("  Compliance: ", ConsoleColor.DarkGray);
+        var pctColor = report.Summary.CompliancePercentage >= 80 ? ConsoleColor.Green
+            : report.Summary.CompliancePercentage >= 50 ? ConsoleColor.Yellow
+            : ConsoleColor.Red;
+        WriteLineColored($"{report.Summary.CompliancePercentage:F1}%", pctColor);
+        Console.WriteLine();
+
+        // Summary bar
+        WriteLineColored("  Summary", ConsoleColor.White);
+        WriteLineColored("  ───────────────────────────────────────", ConsoleColor.DarkGray);
+        WriteColored("    Pass:         ", ConsoleColor.DarkGray);
+        WriteLineColored($"{report.Summary.PassCount}", ConsoleColor.Green);
+        WriteColored("    Fail:         ", ConsoleColor.DarkGray);
+        WriteLineColored($"{report.Summary.FailCount}", ConsoleColor.Red);
+        WriteColored("    Partial:      ", ConsoleColor.DarkGray);
+        WriteLineColored($"{report.Summary.PartialCount}", ConsoleColor.Yellow);
+        WriteColored("    Not Assessed: ", ConsoleColor.DarkGray);
+        WriteLineColored($"{report.Summary.NotAssessedCount}", ConsoleColor.DarkGray);
+        Console.WriteLine();
+
+        // Control details
+        WriteLineColored("  Controls", ConsoleColor.White);
+        WriteLineColored("  ───────────────────────────────────────", ConsoleColor.DarkGray);
+
+        foreach (var control in report.Controls)
+        {
+            var (icon, color) = control.Status switch
+            {
+                ControlStatus.Pass => ("✅", ConsoleColor.Green),
+                ControlStatus.Fail => ("❌", ConsoleColor.Red),
+                ControlStatus.Partial => ("⚠️", ConsoleColor.Yellow),
+                _ => ("─ ", ConsoleColor.DarkGray)
+            };
+
+            WriteColored($"    {icon} ", color);
+            WriteColored($"[{control.ControlId}] ", ConsoleColor.DarkCyan);
+            WriteLineColored(control.ControlTitle, ConsoleColor.White);
+
+            if (control.Status == ControlStatus.Fail || control.Status == ControlStatus.Partial)
+            {
+                // Show related findings
+                foreach (var finding in control.RelatedFindings)
+                {
+                    if (finding.Severity == Core.Models.Severity.Pass) continue;
+                    var sevColor = finding.Severity == Core.Models.Severity.Critical
+                        ? ConsoleColor.Red : ConsoleColor.Yellow;
+                    WriteColored($"         ", ConsoleColor.DarkGray);
+                    WriteColored($"[{finding.Severity}] ", sevColor);
+                    WriteLineColored(finding.Title, ConsoleColor.DarkGray);
+                }
+
+                // Show remediation hints
+                if (control.Remediation.Count > 0)
+                {
+                    WriteColored("         💡 ", ConsoleColor.DarkGray);
+                    WriteLineColored(control.Remediation[0], ConsoleColor.DarkYellow);
+                }
+            }
+        }
+
+        Console.WriteLine();
+    }
+
+    /// <summary>
+    /// Print a cross-framework compliance comparison.
+    /// </summary>
+    public static void PrintCrossFrameworkCompliance(CrossFrameworkSummary summary)
+    {
+        Console.WriteLine();
+        WriteLineColored("  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+        WriteLineColored("  ║       📊  Cross-Framework Compliance        ║", ConsoleColor.Cyan);
+        WriteLineColored("  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        WriteColored("  Security Score: ", ConsoleColor.DarkGray);
+        var scoreColor = summary.SecurityScore >= 80 ? ConsoleColor.Green
+            : summary.SecurityScore >= 60 ? ConsoleColor.Yellow
+            : ConsoleColor.Red;
+        WriteLineColored($"{summary.SecurityScore}/100", scoreColor);
+        Console.WriteLine();
+
+        // Framework comparison table
+        WriteLineColored("  Framework                          Compliance   Verdict          Pass  Fail  Partial", ConsoleColor.White);
+        WriteLineColored("  ────────────────────────────────── ────────── ──────────────── ───── ───── ───────", ConsoleColor.DarkGray);
+
+        foreach (var fw in summary.FrameworkResults)
+        {
+            var pctColor = fw.CompliancePercentage >= 80 ? ConsoleColor.Green
+                : fw.CompliancePercentage >= 50 ? ConsoleColor.Yellow
+                : ConsoleColor.Red;
+            var verdictColor = fw.Verdict switch
+            {
+                ComplianceVerdict.Compliant => ConsoleColor.Green,
+                ComplianceVerdict.PartiallyCompliant => ConsoleColor.Yellow,
+                ComplianceVerdict.NonCompliant => ConsoleColor.Red,
+                _ => ConsoleColor.DarkGray
+            };
+
+            WriteColored($"  {fw.FrameworkName,-36} ", ConsoleColor.White);
+            WriteColored($"{fw.CompliancePercentage,8:F1}%  ", pctColor);
+            WriteColored($"{fw.Verdict,-16} ", verdictColor);
+            WriteColored($"{fw.PassCount,5} ", ConsoleColor.Green);
+            WriteColored($"{fw.FailCount,5} ", ConsoleColor.Red);
+            WriteLineColored($"{fw.PartialCount,7}", ConsoleColor.Yellow);
+        }
+
+        Console.WriteLine();
+
+        // Critical gaps across frameworks
+        var allGaps = summary.FrameworkResults
+            .Where(fw => fw.CriticalGaps.Count > 0)
+            .ToList();
+
+        if (allGaps.Count > 0)
+        {
+            WriteLineColored("  Critical Gaps", ConsoleColor.White);
+            WriteLineColored("  ───────────────────────────────────────", ConsoleColor.DarkGray);
+
+            foreach (var fw in allGaps)
+            {
+                WriteLineColored($"    {fw.FrameworkName}:", ConsoleColor.DarkCyan);
+                foreach (var gap in fw.CriticalGaps.Take(5))
+                {
+                    WriteColored("      ❌ ", ConsoleColor.Red);
+                    WriteLineColored(gap, ConsoleColor.DarkGray);
+                }
+                if (fw.CriticalGaps.Count > 5)
+                {
+                    WriteLineColored($"      ... and {fw.CriticalGaps.Count - 5} more", ConsoleColor.DarkGray);
+                }
+            }
+            Console.WriteLine();
+        }
+
+        // High-impact fix recommendations (findings that affect multiple frameworks)
+        var findingFrameworkCounts = new Dictionary<string, List<string>>();
+        foreach (var fw in summary.FrameworkResults)
+        {
+            foreach (var gap in fw.CriticalGaps)
+            {
+                // Extract the control title after ": "
+                var colonIdx = gap.IndexOf(": ");
+                var title = colonIdx >= 0 ? gap[(colonIdx + 2)..] : gap;
+                if (!findingFrameworkCounts.ContainsKey(title))
+                    findingFrameworkCounts[title] = new List<string>();
+                findingFrameworkCounts[title].Add(fw.FrameworkId);
+            }
+        }
+
+        var multiFrameworkGaps = findingFrameworkCounts
+            .Where(kv => kv.Value.Count > 1)
+            .OrderByDescending(kv => kv.Value.Count)
+            .Take(5)
+            .ToList();
+
+        if (multiFrameworkGaps.Count > 0)
+        {
+            WriteLineColored("  🎯 High-Impact Fixes (affect multiple frameworks)", ConsoleColor.White);
+            WriteLineColored("  ───────────────────────────────────────", ConsoleColor.DarkGray);
+
+            foreach (var gap in multiFrameworkGaps)
+            {
+                WriteColored($"    [{gap.Value.Count} frameworks] ", ConsoleColor.Magenta);
+                WriteLineColored(gap.Key, ConsoleColor.White);
+                WriteColored("      Frameworks: ", ConsoleColor.DarkGray);
+                WriteLineColored(string.Join(", ", gap.Value), ConsoleColor.DarkCyan);
+            }
+            Console.WriteLine();
+        }
+    }
+
+    /// <summary>
+    /// Render a single-framework compliance report as CSV.
+    /// </summary>
+    public static string RenderComplianceCsv(ComplianceReport report)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("ControlId,ControlTitle,Status,FindingCount,Remediation");
+        foreach (var control in report.Controls)
+        {
+            var remediation = control.Remediation.Count > 0
+                ? control.Remediation[0].Replace("\"", "\"\"")
+                : "";
+            var findingCount = control.RelatedFindings.Count(f =>
+                f.Severity != Core.Models.Severity.Pass);
+            sb.AppendLine($"\"{control.ControlId}\",\"{control.ControlTitle}\",\"{control.Status}\",{findingCount},\"{remediation}\"");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Render a cross-framework summary as CSV.
+    /// </summary>
+    public static string RenderComplianceCrossFrameworkCsv(CrossFrameworkSummary summary)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("FrameworkId,FrameworkName,CompliancePercentage,Verdict,Pass,Fail,Partial,NotAssessed,CriticalGapCount");
+        foreach (var fw in summary.FrameworkResults)
+        {
+            sb.AppendLine($"\"{fw.FrameworkId}\",\"{fw.FrameworkName}\",{fw.CompliancePercentage:F1},\"{fw.Verdict}\",{fw.PassCount},{fw.FailCount},{fw.PartialCount},{fw.NotAssessedCount},{fw.CriticalGaps.Count}");
+        }
+        return sb.ToString();
+    }
+}

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -281,6 +281,7 @@ public static partial class ConsoleFormatter
         WriteHelpEntry("    --policy <action>    ", "Security Policy as Code (export/import/validate/diff)");
         WriteHelpEntry("    --threats            ", "STRIDE threat model from audit findings");
         WriteHelpEntry("    --attack-paths       ", "Kill chain attack path analysis with chokepoints");
+        WriteHelpEntry("    --compliance         ", "Compliance framework evaluation (CIS, NIST, PCI-DSS, HIPAA)");
         WriteHelpEntry("    --help, -h           ", "Show this help message");
         WriteHelpEntry("    --version, -v        ", "Show version information");
         Console.WriteLine();
@@ -314,6 +315,10 @@ public static partial class ConsoleFormatter
         WriteHelpEntry("    --age-module <m>     ", "Filter age report by module name");
         WriteHelpEntry("    --age-class <c>      ", "Filter by classification (chronic/recurring/new/intermittent)");
         WriteHelpEntry("    --age-top <n>        ", "Number of findings to show (default: 10)");
+        Console.WriteLine();
+        Console.WriteLine("  COMPLIANCE OPTIONS:");
+        WriteHelpEntry("    --framework <id>     ", "Framework to evaluate: cis, nist, pci-dss, hipaa (default: cis)");
+        WriteHelpEntry("    --cross-framework    ", "Compare across all frameworks simultaneously");
         Console.WriteLine();
         Console.WriteLine("  EXAMPLES:");
         WriteLineColored("    winsentinel --audit                              # Full audit with colored output", ConsoleColor.DarkGray);
@@ -368,6 +373,11 @@ public static partial class ConsoleFormatter
         WriteLineColored("    winsentinel --age --age-severity critical            # Critical findings only", ConsoleColor.DarkGray);
         WriteLineColored("    winsentinel --age --age-module firewall              # Filter by module", ConsoleColor.DarkGray);
         WriteLineColored("    winsentinel --age --age-days 7 --json               # Last 7 days as JSON", ConsoleColor.DarkGray);
+        WriteLineColored("    winsentinel --compliance                            # CIS compliance check", ConsoleColor.DarkGray);
+        WriteLineColored("    winsentinel --compliance --framework nist           # NIST 800-53 evaluation", ConsoleColor.DarkGray);
+        WriteLineColored("    winsentinel --compliance --framework pci-dss --json # PCI-DSS as JSON", ConsoleColor.DarkGray);
+        WriteLineColored("    winsentinel --compliance --cross-framework          # All frameworks compared", ConsoleColor.DarkGray);
+        WriteLineColored("    winsentinel --compliance --framework hipaa --csv    # HIPAA controls as CSV", ConsoleColor.DarkGray);
         Console.WriteLine();
         Console.WriteLine("  EXIT CODES:");
         Console.WriteLine("    0  All checks pass (or score >= threshold)");

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -42,6 +42,7 @@ return options.Command switch
     CliCommand.ScheduleOptimize => HandleScheduleOptimize(options),
     CliCommand.Digest => await HandleDigest(options),
     CliCommand.AttackPaths => await HandleAttackPaths(options),
+    CliCommand.Compliance => await HandleCompliance(options),
     _ => HandleHelp()
 };
 
@@ -2533,6 +2534,140 @@ static async Task<int> HandleAttackPaths(CliOptions options)
     }
 
     // Save this run to history
+    using var historyService = new AuditHistoryService();
+    historyService.SaveAuditResult(report);
+
+    return 0;
+}
+
+// ── Compliance Framework Evaluation ──────────────────────────────
+
+static async Task<int> HandleCompliance(CliOptions options)
+{
+    var engine = BuildEngine(options.ModulesFilter);
+    var sw = Stopwatch.StartNew();
+
+    if (!options.Quiet)
+    {
+        ConsoleFormatter.PrintBanner();
+        Console.WriteLine("  Running audit for compliance evaluation...");
+        Console.WriteLine();
+    }
+
+    var progress = options.Quiet
+        ? null
+        : new Progress<(string module, int current, int total)>(p =>
+            ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
+
+    var report = await engine.RunFullAuditAsync(progress);
+    sw.Stop();
+
+    if (!options.Quiet)
+    {
+        ConsoleFormatter.PrintProgressDone(engine.Modules.Count, sw.Elapsed);
+    }
+
+    var mapper = new ComplianceMapper();
+
+    if (options.ComplianceCrossFramework || options.ComplianceFramework == "all")
+    {
+        var crossSummary = mapper.CrossFrameworkAnalysis(report);
+
+        if (options.Json)
+        {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                Converters = { new JsonStringEnumConverter() },
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+            var json = JsonSerializer.Serialize(crossSummary, jsonOptions);
+
+            if (!string.IsNullOrWhiteSpace(options.OutputFile))
+            {
+                await File.WriteAllTextAsync(options.OutputFile, json);
+                if (!options.Quiet)
+                    Console.WriteLine($"  Cross-framework report saved to {options.OutputFile}");
+            }
+            else
+            {
+                Console.WriteLine(json);
+            }
+        }
+        else if (options.Csv)
+        {
+            var csv = ConsoleFormatter.RenderComplianceCrossFrameworkCsv(crossSummary);
+            if (!string.IsNullOrWhiteSpace(options.OutputFile))
+            {
+                await File.WriteAllTextAsync(options.OutputFile, csv);
+                if (!options.Quiet)
+                    Console.WriteLine($"  Cross-framework CSV saved to {options.OutputFile}");
+            }
+            else
+            {
+                Console.WriteLine(csv);
+            }
+        }
+        else
+        {
+            ConsoleFormatter.PrintCrossFrameworkCompliance(crossSummary);
+        }
+    }
+    else
+    {
+        var frameworkId = options.ComplianceFramework ?? "cis";
+        var framework = mapper.GetFramework(frameworkId);
+
+        if (framework == null)
+        {
+            ConsoleFormatter.PrintError(
+                $"Unknown framework: '{frameworkId}'. Available: {string.Join(", ", mapper.FrameworkIds)}");
+            return 3;
+        }
+
+        var complianceReport = mapper.Evaluate(report, frameworkId);
+
+        if (options.Json)
+        {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                Converters = { new JsonStringEnumConverter() },
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+            var json = JsonSerializer.Serialize(complianceReport, jsonOptions);
+
+            if (!string.IsNullOrWhiteSpace(options.OutputFile))
+            {
+                await File.WriteAllTextAsync(options.OutputFile, json);
+                if (!options.Quiet)
+                    Console.WriteLine($"  Compliance report saved to {options.OutputFile}");
+            }
+            else
+            {
+                Console.WriteLine(json);
+            }
+        }
+        else if (options.Csv)
+        {
+            var csv = ConsoleFormatter.RenderComplianceCsv(complianceReport);
+            if (!string.IsNullOrWhiteSpace(options.OutputFile))
+            {
+                await File.WriteAllTextAsync(options.OutputFile, csv);
+                if (!options.Quiet)
+                    Console.WriteLine($"  Compliance CSV saved to {options.OutputFile}");
+            }
+            else
+            {
+                Console.WriteLine(csv);
+            }
+        }
+        else
+        {
+            ConsoleFormatter.PrintComplianceReport(complianceReport);
+        }
+    }
+
     using var historyService = new AuditHistoryService();
     historyService.SaveAuditResult(report);
 

--- a/tests/WinSentinel.Tests/Cli/ComplianceCliTests.cs
+++ b/tests/WinSentinel.Tests/Cli/ComplianceCliTests.cs
@@ -1,0 +1,272 @@
+using WinSentinel.Cli;
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+using Xunit;
+
+namespace WinSentinel.Tests.Cli;
+
+public class ComplianceCliTests
+{
+    // ── CLI Parser Tests ─────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_Compliance_SetsCommand()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance" });
+        Assert.Equal(CliCommand.Compliance, opts.Command);
+        Assert.Null(opts.Error);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithFramework_SetsFrameworkId()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--framework", "nist" });
+        Assert.Equal(CliCommand.Compliance, opts.Command);
+        Assert.Equal("nist", opts.ComplianceFramework);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithPciDss_SetsFrameworkId()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--framework", "pci-dss" });
+        Assert.Equal("pci-dss", opts.ComplianceFramework);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithHipaa_SetsFrameworkId()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--framework", "hipaa" });
+        Assert.Equal("hipaa", opts.ComplianceFramework);
+    }
+
+    [Fact]
+    public void Parse_Compliance_CrossFramework_SetsFlag()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--cross-framework" });
+        Assert.Equal(CliCommand.Compliance, opts.Command);
+        Assert.True(opts.ComplianceCrossFramework);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithJson_SetsJsonFlag()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--json" });
+        Assert.Equal(CliCommand.Compliance, opts.Command);
+        Assert.True(opts.Json);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithCsv_SetsCsvFlag()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--csv" });
+        Assert.Equal(CliCommand.Compliance, opts.Command);
+        Assert.True(opts.Csv);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithOutput_SetsOutputFile()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "-o", "report.json", "--json" });
+        Assert.Equal("report.json", opts.OutputFile);
+    }
+
+    [Fact]
+    public void Parse_Compliance_FrameworkAll_EquivalentToCrossFramework()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--framework", "all" });
+        Assert.Equal("all", opts.ComplianceFramework);
+        // In handler, framework=="all" triggers cross-framework mode
+    }
+
+    [Fact]
+    public void Parse_Compliance_MissingFrameworkValue_ReturnsError()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--framework" });
+        Assert.NotNull(opts.Error);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithQuiet_SetsQuietFlag()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--quiet" });
+        Assert.True(opts.Quiet);
+    }
+
+    [Fact]
+    public void Parse_Compliance_WithModulesFilter_SetsFilter()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--modules", "firewall,network" });
+        Assert.Equal("firewall,network", opts.ModulesFilter);
+    }
+
+    [Fact]
+    public void Parse_Compliance_CrossFrameworkAndJson_BothSet()
+    {
+        var opts = CliParser.Parse(new[] { "--compliance", "--cross-framework", "--json" });
+        Assert.True(opts.ComplianceCrossFramework);
+        Assert.True(opts.Json);
+    }
+
+    // ── ConsoleFormatter CSV Tests ───────────────────────────────────
+
+    [Fact]
+    public void RenderComplianceCsv_IncludesHeader()
+    {
+        var report = new ComplianceReport
+        {
+            FrameworkId = "cis",
+            FrameworkName = "CIS",
+            FrameworkVersion = "3.0",
+            Controls = new List<ControlResult>
+            {
+                new()
+                {
+                    ControlId = "CIS-1.1",
+                    ControlTitle = "Password Policy",
+                    Status = ControlStatus.Pass,
+                    RelatedFindings = new List<Finding>(),
+                    Remediation = new List<string>()
+                }
+            },
+            Summary = new ComplianceSummary { TotalControls = 1, PassCount = 1 }
+        };
+
+        var csv = ConsoleFormatter.RenderComplianceCsv(report);
+        Assert.Contains("ControlId,ControlTitle,Status,FindingCount,Remediation", csv);
+        Assert.Contains("CIS-1.1", csv);
+        Assert.Contains("Pass", csv);
+    }
+
+    [Fact]
+    public void RenderComplianceCsv_CountsNonPassFindings()
+    {
+        var report = new ComplianceReport
+        {
+            FrameworkId = "nist",
+            FrameworkName = "NIST",
+            FrameworkVersion = "5",
+            Controls = new List<ControlResult>
+            {
+                new()
+                {
+                    ControlId = "AC-2",
+                    ControlTitle = "Account Management",
+                    Status = ControlStatus.Fail,
+                    RelatedFindings = new List<Finding>
+                    {
+                        Finding.Critical("Test1", "Desc", "Accounts"),
+                        Finding.Warning("Test2", "Desc", "Accounts"),
+                        Finding.Pass("Test3", "Desc", "Accounts")
+                    },
+                    Remediation = new List<string> { "Fix accounts" }
+                }
+            },
+            Summary = new ComplianceSummary { TotalControls = 1, FailCount = 1 }
+        };
+
+        var csv = ConsoleFormatter.RenderComplianceCsv(report);
+        // 2 non-pass findings
+        Assert.Contains(",2,", csv);
+    }
+
+    [Fact]
+    public void RenderComplianceCrossFrameworkCsv_IncludesAllFrameworks()
+    {
+        var summary = new CrossFrameworkSummary
+        {
+            SecurityScore = 75,
+            FrameworkResults = new List<FrameworkResult>
+            {
+                new()
+                {
+                    FrameworkId = "cis",
+                    FrameworkName = "CIS Benchmarks",
+                    CompliancePercentage = 80.0,
+                    Verdict = ComplianceVerdict.PartiallyCompliant,
+                    PassCount = 8,
+                    FailCount = 1,
+                    PartialCount = 1,
+                    NotAssessedCount = 3,
+                    CriticalGaps = new List<string> { "CIS-1.1: Password Policy" }
+                },
+                new()
+                {
+                    FrameworkId = "nist",
+                    FrameworkName = "NIST 800-53",
+                    CompliancePercentage = 70.0,
+                    Verdict = ComplianceVerdict.NonCompliant,
+                    PassCount = 7,
+                    FailCount = 3,
+                    PartialCount = 0,
+                    NotAssessedCount = 6,
+                    CriticalGaps = new List<string>()
+                }
+            }
+        };
+
+        var csv = ConsoleFormatter.RenderComplianceCrossFrameworkCsv(summary);
+        Assert.Contains("FrameworkId,FrameworkName", csv);
+        Assert.Contains("cis", csv);
+        Assert.Contains("nist", csv);
+        Assert.Contains("80.0", csv);
+        Assert.Contains("70.0", csv);
+    }
+
+    [Fact]
+    public void RenderComplianceCsv_EscapesQuotesInRemediation()
+    {
+        var report = new ComplianceReport
+        {
+            FrameworkId = "cis",
+            FrameworkName = "CIS",
+            FrameworkVersion = "3.0",
+            Controls = new List<ControlResult>
+            {
+                new()
+                {
+                    ControlId = "CIS-1.1",
+                    ControlTitle = "Test",
+                    Status = ControlStatus.Fail,
+                    RelatedFindings = new List<Finding>
+                    {
+                        Finding.Critical("F1", "Desc", "Accounts")
+                    },
+                    Remediation = new List<string> { "Run \"secpol.msc\" to fix" }
+                }
+            },
+            Summary = new ComplianceSummary { TotalControls = 1, FailCount = 1 }
+        };
+
+        var csv = ConsoleFormatter.RenderComplianceCsv(report);
+        // Quotes should be doubled for CSV escaping
+        Assert.Contains("\"\"secpol.msc\"\"", csv);
+    }
+
+    [Fact]
+    public void RenderComplianceCrossFrameworkCsv_IncludesCriticalGapCount()
+    {
+        var summary = new CrossFrameworkSummary
+        {
+            SecurityScore = 50,
+            FrameworkResults = new List<FrameworkResult>
+            {
+                new()
+                {
+                    FrameworkId = "hipaa",
+                    FrameworkName = "HIPAA",
+                    CompliancePercentage = 60.0,
+                    Verdict = ComplianceVerdict.NonCompliant,
+                    PassCount = 3,
+                    FailCount = 5,
+                    PartialCount = 2,
+                    NotAssessedCount = 1,
+                    CriticalGaps = new List<string> { "Gap1", "Gap2", "Gap3" }
+                }
+            }
+        };
+
+        var csv = ConsoleFormatter.RenderComplianceCrossFrameworkCsv(summary);
+        Assert.Contains("CriticalGapCount", csv);
+        Assert.Contains(",3", csv);  // 3 critical gaps
+    }
+}


### PR DESCRIPTION
## Summary

Expose the existing \ComplianceMapper\ service via a new \--compliance\ CLI command, enabling users to evaluate their security posture against industry compliance frameworks directly from the command line.

## New CLI Command

\\\ash
# Evaluate against CIS Benchmarks (default)
winsentinel --compliance

# Evaluate against a specific framework
winsentinel --compliance --framework nist
winsentinel --compliance --framework pci-dss
winsentinel --compliance --framework hipaa

# Cross-framework comparison
winsentinel --compliance --cross-framework
winsentinel --compliance --framework all

# Export formats
winsentinel --compliance --json -o compliance.json
winsentinel --compliance --csv -o compliance.csv
winsentinel --compliance --cross-framework --json
\\\

## Features

- **Single framework evaluation**: Control-level pass/fail/partial status with related findings and remediation hints
- **Cross-framework comparison**: Side-by-side table showing compliance % across CIS, NIST, PCI-DSS, and HIPAA
- **High-impact fix recommendations**: Identifies findings that affect multiple frameworks for maximum ROI
- **Critical gaps**: Lists failing controls per framework
- **Output formats**: Console (color-coded), JSON, CSV with file output support

## Files Changed

- \CliParser.cs\: Added \Compliance\ command, \--framework\ and \--cross-framework\ options
- \Program.cs\: Added \HandleCompliance\ handler
- \ConsoleFormatter.Compliance.cs\: New partial class for compliance output formatting
- \ConsoleFormatter.cs\: Added help text and examples
- \ComplianceCliTests.cs\: 18 tests covering parsing, CSV rendering, and edge cases

## Tests

All 18 new tests pass. Build succeeds with 0 errors.