### PR TITLE
fix: Race condition in ScanScheduler.Stop() causes ObjectDisposedException

### DIFF
--- a/src/WinSentinel.Core/Services/ScanScheduler.cs
+++ b/src/WinSentinel.Core/Services/ScanScheduler.cs
@@ -93,13 +93,22 @@ public class ScanScheduler : IDisposable
         _timer?.Dispose();
         _timer = null;
 
-        // Safely cancel any in-progress scan under the lock
-        CancellationTokenSource? cts;
+        // Cancel any in-progress scan. Must read _and_ cancel under the lock
+        // to avoid a race where ExecuteScanAsync's finally block disposes the
+        // CTS between our read and our Cancel() call, which would throw
+        // ObjectDisposedException.
         lock (_lock)
         {
-            cts = _scanCts;
+            try
+            {
+                _scanCts?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // CTS was disposed between our null-check and Cancel() call
+                // by the ExecuteScanAsync finally block — safe to ignore.
+            }
         }
-        cts?.Cancel();
 
         SchedulerStateChanged?.Invoke(this, false);
     }


### PR DESCRIPTION
## Problem

\Stop()\ reads \_scanCts\ under the lock but calls \Cancel()\ **outside** it. If \ExecuteScanAsync\'s \inally\ block disposes the CTS between the read and the \Cancel()\ call, an \ObjectDisposedException\ is thrown. This is a classic TOCTOU (time-of-check-time-of-use) race condition.

### Timeline of the race:
1. \Stop()\ acquires lock, reads \_scanCts\ → gets CTS reference, releases lock
2. \ExecuteScanAsync\ finally block acquires lock, sets \_scanCts = null\, releases lock, disposes \scanCts\
3. \Stop()\ calls \cts.Cancel()\ on the now-disposed CTS → 💥 \ObjectDisposedException\

## Fix

Move the \Cancel()\ call inside the lock so it happens atomically with the read. Also catch \ObjectDisposedException\ defensively for the narrow window between null-check and Cancel().

## Impact

This bug would manifest as an unhandled exception when stopping the scheduler while a scan is completing, potentially crashing the agent service.