### PR TITLE
fix: add try-catch guard to async void OnTimerElapsed

### DIFF
--- a/src/WinSentinel.Core/Services/ScanScheduler.cs
+++ b/src/WinSentinel.Core/Services/ScanScheduler.cs
@@ -128,7 +128,18 @@ public class ScanScheduler : IDisposable
 
     private async void OnTimerElapsed(object? state)
     {
-        await ExecuteScanAsync(isScheduled: true, CancellationToken.None);
+        try
+        {
+            await ExecuteScanAsync(isScheduled: true, CancellationToken.None);
+        }
+        catch (Exception ex)
+        {
+            // ExecuteScanAsync already catches internally, but guard against
+            // any edge-case throw (e.g. ObjectDisposedException on _scanCts)
+            // so the timer callback never crashes the process.
+            System.Diagnostics.Debug.WriteLine(
+                $"[WinSentinel] Unhandled error in scheduled scan: {ex.Message}");
+        }
     }
 
     private async Task<SecurityReport?> ExecuteScanAsync(bool isScheduled, CancellationToken externalToken)


### PR DESCRIPTION
The timer callback \OnTimerElapsed\ was \sync void\ without its own try-catch. While \ExecuteScanAsync\ catches internally, edge cases (e.g. \ObjectDisposedException\ on \_scanCts\) could bubble up and crash the process since \sync void\ exceptions are unobservable.

Added a defensive try-catch around the await to ensure the timer callback never throws to the thread pool.