### PR TITLE
feat: add --changelog CLI command

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -81,6 +81,9 @@ public class CliOptions
     public int WhatIfTopN { get; set; } = 5;
     public string SummaryFormat { get; set; } = "text";
     public int SummaryTrendDays { get; set; } = 30;
+    public int ChangelogDays { get; set; } = 30;
+    public string ChangelogFormat { get; set; } = "text";
+    public string? ChangelogImpactFilter { get; set; }
 }
 
 public enum CliCommand
@@ -110,6 +113,7 @@ public enum CliCommand
     AttackPaths,
     WhatIf,
     Summary,
+    Changelog,
     Help,
     Version
 }
@@ -425,6 +429,28 @@ public static class CliParser
 
                 case "--summary":
                     options.Command = CliCommand.Summary;
+                    break;
+
+                case "--changelog":
+                    options.Command = CliCommand.Changelog;
+                    break;
+
+                case "--changelog-days":
+                    if (!TryConsumeInt(args, ref i, "--changelog-days", 1, 365, out var clDays, out var clDaysErr))
+                    { options.Error = clDaysErr; return options; }
+                    options.ChangelogDays = clDays;
+                    break;
+
+                case "--changelog-format":
+                    if (!TryConsumeArg(args, ref i, "--changelog-format", out var clFmt, out var clFmtErr))
+                    { options.Error = clFmtErr; return options; }
+                    options.ChangelogFormat = clFmt.ToLowerInvariant();
+                    break;
+
+                case "--changelog-impact":
+                    if (!TryConsumeArg(args, ref i, "--changelog-impact", out var clImpact, out var clImpactErr))
+                    { options.Error = clImpactErr; return options; }
+                    options.ChangelogImpactFilter = clImpact.ToLowerInvariant();
                     break;
 
                 case "--summary-format":

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -282,6 +282,7 @@ public static partial class ConsoleFormatter
         WriteHelpEntry("    --threats            ", "STRIDE threat model from audit findings");
         WriteHelpEntry("    --attack-paths       ", "Kill chain attack path analysis with chokepoints");
         WriteHelpEntry("    --summary            ", "Executive security summary (plain-English brief)");
+        WriteHelpEntry("    --changelog          ", "Security changelog across audit history");
         WriteHelpEntry("    --help, -h           ", "Show this help message");
         WriteHelpEntry("    --version, -v        ", "Show version information");
         Console.WriteLine();
@@ -317,6 +318,9 @@ public static partial class ConsoleFormatter
         WriteHelpEntry("    --age-top <n>        ", "Number of findings to show (default: 10)");
         WriteHelpEntry("    --summary-format <f> ", "Summary format: text (default), json, md");
         WriteHelpEntry("    --summary-trend-days ", "Trend lookback for summary (default: 30)");
+        WriteHelpEntry("    --changelog-days <n> ", "Changelog lookback in days (default: 30)");
+        WriteHelpEntry("    --changelog-format <f>", "Changelog format: text (default), json, md");
+        WriteHelpEntry("    --changelog-impact <i>", "Filter: positive, negative, or neutral");
         Console.WriteLine();
         Console.WriteLine("  EXAMPLES:");
         WriteLineColored("    winsentinel --audit                              # Full audit with colored output", ConsoleColor.DarkGray);

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -44,6 +44,7 @@ return options.Command switch
     CliCommand.AttackPaths => await HandleAttackPaths(options),
     CliCommand.WhatIf => await HandleWhatIf(options),
     CliCommand.Summary => await HandleSummary(options),
+    CliCommand.Changelog => await HandleChangelog(options),
     _ => HandleHelp()
 };
 
@@ -2475,4 +2476,134 @@ static async Task<int> HandleSummary(CliOptions options)
     historyService.SaveAuditResult(report);
 
     return 0;
+}
+
+// ── Security Changelog ───────────────────────────────────────────
+
+static Task<int> HandleChangelog(CliOptions options)
+{
+    using var historyService = new AuditHistoryService();
+    historyService.EnsureDatabase();
+
+    var runs = historyService.GetHistory(options.ChangelogDays);
+
+    if (runs.Count < 2)
+    {
+        if (options.Json)
+        {
+            WriteOutput("{\"error\": \"Need at least 2 audit runs to generate a changelog. Run more audits first.\"}", options.OutputFile);
+        }
+        else
+        {
+            ConsoleFormatter.PrintWarning("Need at least 2 audit runs to generate a changelog. Run more audits first.");
+        }
+        return Task.FromResult(1);
+    }
+
+    // Load full details for each run
+    for (int i = 0; i < runs.Count; i++)
+    {
+        var fullRun = historyService.GetRunDetails(runs[i].Id);
+        if (fullRun != null)
+        {
+            runs[i].Findings = fullRun.Findings;
+            runs[i].ModuleScores = fullRun.ModuleScores;
+        }
+    }
+
+    // Reconstruct SecurityReport objects from AuditRunRecords (oldest first)
+    var reports = runs
+        .OrderBy(r => r.Timestamp)
+        .Select(ReconstructReport)
+        .ToList();
+
+    var changelogService = new SecurityChangelogService();
+    var changelog = changelogService.Generate(reports, "WinSentinel Security Changelog");
+
+    // Apply impact filter if specified
+    if (!string.IsNullOrEmpty(options.ChangelogImpactFilter))
+    {
+        if (Enum.TryParse<SecurityChangelogService.Impact>(options.ChangelogImpactFilter, true, out var impact))
+        {
+            changelog = changelogService.FilterByImpact(changelog, impact);
+        }
+    }
+
+    // Remove empty versions for cleaner output
+    changelog = changelogService.FilterEmpty(changelog);
+
+    var output = options.ChangelogFormat switch
+    {
+        "json" => changelogService.ToJson(changelog),
+        "md" or "markdown" => changelogService.ToMarkdown(changelog),
+        _ => changelogService.ToText(changelog)
+    };
+
+    if (!string.IsNullOrWhiteSpace(options.OutputFile))
+    {
+        File.WriteAllText(options.OutputFile, output);
+        if (!options.Quiet)
+            Console.WriteLine($"  Changelog saved to {options.OutputFile}");
+    }
+    else
+    {
+        Console.WriteLine(output);
+    }
+
+    return Task.FromResult(0);
+}
+
+// Reconstruct a SecurityReport from an AuditRunRecord for changelog generation.
+static SecurityReport ReconstructReport(AuditRunRecord run)
+{
+    var moduleGroups = run.Findings
+        .GroupBy(f => f.ModuleName)
+        .ToDictionary(g => g.Key, g => g.ToList());
+
+    var results = new List<AuditResult>();
+
+    foreach (var ms in run.ModuleScores)
+    {
+        var findings = moduleGroups.GetValueOrDefault(ms.ModuleName, []);
+        results.Add(new AuditResult
+        {
+            ModuleName = ms.ModuleName,
+            Category = ms.Category,
+            Findings = findings.Select(f => new Finding
+            {
+                Title = f.Title,
+                Description = f.Description,
+                Severity = Enum.TryParse<Severity>(f.Severity, true, out var sev) ? sev : Severity.Info,
+                Remediation = f.Remediation ?? ""
+            }).ToList(),
+            Success = true
+        });
+    }
+
+    foreach (var (moduleName, findings) in moduleGroups)
+    {
+        if (run.ModuleScores.Any(ms => ms.ModuleName == moduleName))
+            continue;
+
+        results.Add(new AuditResult
+        {
+            ModuleName = moduleName,
+            Category = moduleName,
+            Findings = findings.Select(f => new Finding
+            {
+                Title = f.Title,
+                Description = f.Description,
+                Severity = Enum.TryParse<Severity>(f.Severity, true, out var sev) ? sev : Severity.Info,
+                Remediation = f.Remediation ?? ""
+            }).ToList(),
+            Success = true
+        });
+    }
+
+    return new SecurityReport
+    {
+        Results = results,
+        GeneratedAt = run.Timestamp,
+        SecurityScore = run.OverallScore
+    };
 }


### PR DESCRIPTION
Exposes the existing SecurityChangelogService via a new \--changelog\ CLI command, enabling users to generate a versioned changelog of security posture changes across their audit history.

## New CLI Options

| Flag | Description |
|------|-------------|
| \--changelog\ | Generate changelog from stored audit runs |
| \--changelog-days <n>\ | Lookback period in days (default: 30) |
| \--changelog-format <f>\ | Output format: text (default), json, md |
| \--changelog-impact <i>\ | Filter by impact: positive, negative, neutral |

## Example Usage

\\\ash
winsentinel --changelog
winsentinel --changelog --changelog-days 7 --changelog-format md
winsentinel --changelog --changelog-impact negative --json
winsentinel --changelog --changelog-format md -o changelog.md
\\\

## Implementation

- Reconstructs SecurityReport objects from AuditRunRecord history
- Feeds into existing SecurityChangelogService (previously only programmatic)
- Supports text, Markdown, and JSON output formats
- Impact filtering and empty-version filtering included