### PR TITLE
fix: remove dead entries from SafeTempPatterns that never matched

### DIFF
--- a/src/WinSentinel.Agent/Modules/FileSystemMonitorModule.cs
+++ b/src/WinSentinel.Agent/Modules/FileSystemMonitorModule.cs
@@ -109,10 +109,10 @@ public class FileSystemMonitorModule : IAgentModule
         @"\Microsoft.NET\",
     };
 
-    /// <summary>Known-safe process-created temp file patterns.</summary>
+    /// <summary>Known-safe process-created temp file extensions (with leading dot).</summary>
     private static readonly string[] SafeTempPatterns = new[]
     {
-        "tmp", "~", ".tmp", ".log", ".etl", ".diagsession", ".lock"
+        ".tmp", ".log", ".etl", ".diagsession", ".lock"
     };
 
     // ── Watched directory categories ──

--- a/tests/WinSentinel.Tests/Agent/FileSystemMonitorModuleTests.cs
+++ b/tests/WinSentinel.Tests/Agent/FileSystemMonitorModuleTests.cs
@@ -378,9 +378,20 @@ public class FileSystemMonitorModuleTests
     [InlineData(@"C:\Users\Test\AppData\Local\Temp\data.tmp")]
     [InlineData(@"C:\Users\Test\AppData\Local\Temp\session.log")]
     [InlineData(@"C:\Users\Test\AppData\Local\Temp\trace.etl")]
+    [InlineData(@"C:\Users\Test\AppData\Local\Temp\process.lock")]
+    [InlineData(@"C:\Users\Test\AppData\Local\Temp\session.diagsession")]
     public void IsKnownSafe_ReturnsTrueForSafeTempExtensions(string path)
     {
         Assert.True(FileSystemMonitorModule.IsKnownSafe(path));
+    }
+
+    [Theory]
+    [InlineData(@"C:\Users\Test\AppData\Local\Temp\payload.exe")]
+    [InlineData(@"C:\Users\Test\AppData\Local\Temp\script.ps1")]
+    [InlineData(@"C:\Users\Test\AppData\Local\Temp\backup~")]
+    public void IsKnownSafe_ReturnsFalseForDangerousTempFiles(string path)
+    {
+        Assert.False(FileSystemMonitorModule.IsKnownSafe(path));
     }
 
     // ── System32 Drop Detection (static method) ──


### PR DESCRIPTION
SafeTempPatterns contained dotless entries (tmp, ~) compared against Path.GetExtension() which always returns with a dot. These entries were dead code. Removed them and added regression tests.