### PR TITLE
fix: escape double-quotes in toast notification XML

### DIFF
--- a/src/WinSentinel.Core/Services/NotificationService.cs
+++ b/src/WinSentinel.Core/Services/NotificationService.cs
@@ -140,8 +140,8 @@ public class WindowsToastSender : IToastSender
         // XML-escape only — single-quote escaping for PowerShell is handled later
         // by xml.Replace("'", "''") on the full XML string. Escaping here AND there
         // causes double-escaping: it's → it''s → it''''s in the PS string.
-        var escapedTitle = title.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
-        var escapedBody = body.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\n", "&#10;");
+        var escapedTitle = title.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");
+        var escapedBody = body.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;").Replace("\n", "&#10;");
 
         var xml = $@"<toast>
   <visual>


### PR DESCRIPTION
Title and body text containing double-quote characters would produce malformed XML in \SendToastViaPowerShell\, potentially causing toast notifications to silently fail. Adds \&quot;\ escaping alongside the existing \&amp;\, \&lt;\, and \&gt;\ escapes.