### PR TITLE
feat: Add --benchmark CLI command for peer group comparison

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -74,6 +74,8 @@ public class CliOptions
     public int ScheduleOptimizeDays { get; set; } = 90;
     public int DigestHistoryDays { get; set; } = 30;
     public string DigestFormat { get; set; } = "text";
+    public string? BenchmarkGroup { get; set; }
+    public bool BenchmarkAll { get; set; }
 }
 
 public enum CliCommand
@@ -101,6 +103,7 @@ public enum CliCommand
     ScheduleOptimize,
     Digest,
     AttackPaths,
+    Benchmark,
     Help,
     Version
 }
@@ -402,6 +405,23 @@ public static class CliParser
 
                 case "--attack-paths":
                     options.Command = CliCommand.AttackPaths;
+                    break;
+
+                case "--benchmark":
+                    options.Command = CliCommand.Benchmark;
+                    // Next arg can be the peer group: home, developer, enterprise, server, all
+                    if (i + 1 < args.Length && !args[i + 1].StartsWith("-"))
+                    {
+                        var groupArg = args[++i].ToLowerInvariant();
+                        if (groupArg == "all")
+                        {
+                            options.BenchmarkAll = true;
+                        }
+                        else
+                        {
+                            options.BenchmarkGroup = groupArg;
+                        }
+                    }
                     break;
 
                 case "--digest-days":

--- a/src/WinSentinel.Cli/ConsoleFormatter.Benchmark.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Benchmark.cs
@@ -1,0 +1,202 @@
+using WinSentinel.Core.Services;
+using static WinSentinel.Core.Services.PeerBenchmarkService;
+
+namespace WinSentinel.Cli;
+
+public static partial class ConsoleFormatter
+{
+    public static void PrintBenchmarkResult(BenchmarkResult result)
+    {
+        Console.WriteLine();
+        WriteLineColored("  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+        WriteLineColored($"  ║    📊 Peer Benchmark: {result.Group,-12}            ║", ConsoleColor.Cyan);
+        WriteLineColored("  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        // Overall comparison
+        WriteLineColored("  OVERALL", ConsoleColor.White);
+        WriteLineColored("  ──────────────────────────────────────────", ConsoleColor.DarkGray);
+
+        Console.Write("  Your Score:     ");
+        WriteLineColored($"{result.SystemOverallScore}/100", GetBenchmarkScoreColor(result.SystemOverallScore));
+
+        Console.Write("  Peer Median:    ");
+        WriteLineColored($"{result.PeerOverallMedian}/100", ConsoleColor.White);
+
+        var delta = result.SystemOverallScore - result.PeerOverallMedian;
+        Console.Write("  Delta:          ");
+        if (delta > 0)
+            WriteLineColored($"+{delta} points above peers", ConsoleColor.Green);
+        else if (delta < 0)
+            WriteLineColored($"{delta} points below peers", ConsoleColor.Red);
+        else
+            WriteLineColored("At peer median", ConsoleColor.DarkGray);
+
+        Console.Write("  Percentile:     ");
+        WriteLineColored($"{result.OverallPercentile:F0}th ({result.OverallRating})", ConsoleColor.White);
+
+        Console.Write("  Categories:     ");
+        if (result.CategoriesAbovePeer > 0)
+            WriteColored($"{result.CategoriesAbovePeer} above", ConsoleColor.Green);
+        else
+            WriteColored("0 above", ConsoleColor.DarkGray);
+        Console.Write(" │ ");
+        WriteColored($"{result.CategoriesAtPeer} at", ConsoleColor.White);
+        Console.Write(" │ ");
+        if (result.CategoriesBelowPeer > 0)
+            WriteLineColored($"{result.CategoriesBelowPeer} below", ConsoleColor.Red);
+        else
+            WriteLineColored("0 below", ConsoleColor.DarkGray);
+
+        Console.WriteLine();
+
+        // Top Strengths
+        if (result.TopStrengths.Count > 0)
+        {
+            WriteLineColored("  STRENGTHS (above peers)", ConsoleColor.Green);
+            WriteLineColored("  ──────────────────────────────────────────", ConsoleColor.DarkGray);
+            foreach (var s in result.TopStrengths)
+            {
+                Console.Write("  + ");
+                WriteColored($"{s.Category,-20}", ConsoleColor.White);
+                WriteColored($"{s.SystemScore}", GetBenchmarkScoreColor(s.SystemScore));
+                Console.Write(" vs ");
+                WriteColored($"{s.PeerMedian}", ConsoleColor.DarkGray);
+                Console.Write(" median  ");
+                WriteLineColored($"(+{s.Delta})", ConsoleColor.Green);
+            }
+            Console.WriteLine();
+        }
+
+        // Top Weaknesses
+        if (result.TopWeaknesses.Count > 0)
+        {
+            WriteLineColored("  WEAKNESSES (below peers)", ConsoleColor.Red);
+            WriteLineColored("  ──────────────────────────────────────────", ConsoleColor.DarkGray);
+            foreach (var w in result.TopWeaknesses)
+            {
+                Console.Write("  - ");
+                WriteColored($"{w.Category,-20}", ConsoleColor.White);
+                WriteColored($"{w.SystemScore}", GetBenchmarkScoreColor(w.SystemScore));
+                Console.Write(" vs ");
+                WriteColored($"{w.PeerMedian}", ConsoleColor.DarkGray);
+                Console.Write(" median  ");
+                WriteLineColored($"({w.Delta})", ConsoleColor.Red);
+            }
+            Console.WriteLine();
+        }
+
+        // Category breakdown table
+        WriteLineColored("  CATEGORY BREAKDOWN", ConsoleColor.White);
+        WriteLineColored("  ──────────────────────────────────────────────────────────────────", ConsoleColor.DarkGray);
+        WriteColored("  Category             Score  Median  Delta  Pctl   Rating", ConsoleColor.DarkGray);
+        Console.WriteLine();
+
+        foreach (var c in result.Categories)
+        {
+            Console.Write($"  {c.Category,-20} ");
+            WriteColored($"{c.SystemScore,5}", GetBenchmarkScoreColor(c.SystemScore));
+            Console.Write($"  {c.PeerMedian,6}  ");
+
+            if (c.Delta >= 0)
+                WriteColored($"{("+" + c.Delta),5}", ConsoleColor.Green);
+            else
+                WriteColored($"{c.Delta,5}", ConsoleColor.Red);
+
+            Console.Write($"  {c.Percentile,3:F0}%  ");
+
+            var ratingColor = c.Rating switch
+            {
+                ComparisonRating.WellAbovePeer => ConsoleColor.Green,
+                ComparisonRating.AbovePeer => ConsoleColor.Green,
+                ComparisonRating.AtPeer => ConsoleColor.White,
+                ComparisonRating.BelowPeer => ConsoleColor.Yellow,
+                ComparisonRating.WellBelowPeer => ConsoleColor.Red,
+                _ => ConsoleColor.Gray
+            };
+            var ratingText = c.Rating switch
+            {
+                ComparisonRating.WellAbovePeer => "★★ Well Above",
+                ComparisonRating.AbovePeer => "★  Above",
+                ComparisonRating.AtPeer => "•  At Peer",
+                ComparisonRating.BelowPeer => "▽  Below",
+                ComparisonRating.WellBelowPeer => "▼▼ Well Below",
+                _ => "?"
+            };
+            WriteLineColored($" {ratingText}", ratingColor);
+        }
+        Console.WriteLine();
+
+        // Improvement suggestions
+        if (result.Suggestions.Count > 0)
+        {
+            WriteLineColored("  IMPROVEMENT SUGGESTIONS", ConsoleColor.White);
+            WriteLineColored("  ──────────────────────────────────────────", ConsoleColor.DarkGray);
+
+            var displayed = result.Suggestions.Take(10).ToList();
+            for (int i = 0; i < displayed.Count; i++)
+            {
+                var s = displayed[i];
+                var priorityColor = s.Priority switch
+                {
+                    ImprovementPriority.Critical => ConsoleColor.Red,
+                    ImprovementPriority.High => ConsoleColor.Yellow,
+                    ImprovementPriority.Medium => ConsoleColor.Cyan,
+                    ImprovementPriority.Low => ConsoleColor.DarkGray,
+                    _ => ConsoleColor.Gray
+                };
+                Console.Write($"  {i + 1,2}. ");
+                WriteColored($"[{s.Priority}]", priorityColor);
+                Console.Write($" {s.Category}: ");
+                WriteLineColored(s.Recommendation, ConsoleColor.White);
+                WriteLineColored($"       Gap: {s.Gap} pts (you: {s.CurrentScore}, peers: {s.PeerMedian})", ConsoleColor.DarkGray);
+            }
+
+            if (result.Suggestions.Count > 10)
+            {
+                WriteLineColored($"  ... and {result.Suggestions.Count - 10} more", ConsoleColor.DarkGray);
+            }
+            Console.WriteLine();
+        }
+    }
+
+    public static void PrintBenchmarkAllSummary(Dictionary<PeerGroup, BenchmarkResult> results)
+    {
+        Console.WriteLine();
+        WriteLineColored("  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+        WriteLineColored("  ║    📊 Peer Benchmark: All Groups            ║", ConsoleColor.Cyan);
+        WriteLineColored("  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        WriteLineColored("  Group          Score  Median  Delta  Percentile  Rating", ConsoleColor.DarkGray);
+        WriteLineColored("  ─────────────────────────────────────────────────────────────", ConsoleColor.DarkGray);
+
+        foreach (var (group, result) in results.OrderBy(kv => kv.Key))
+        {
+            Console.Write($"  {group,-14} ");
+            WriteColored($"{result.SystemOverallScore,5}", GetBenchmarkScoreColor(result.SystemOverallScore));
+            Console.Write($"  {result.PeerOverallMedian,6}  ");
+
+            var d = result.SystemOverallScore - result.PeerOverallMedian;
+            if (d >= 0)
+                WriteColored($"{("+" + d),5}", ConsoleColor.Green);
+            else
+                WriteColored($"{d,5}", ConsoleColor.Red);
+
+            Console.Write($"  {result.OverallPercentile,8:F0}th  ");
+            WriteLineColored(result.OverallRating, ConsoleColor.White);
+        }
+
+        Console.WriteLine();
+
+        WriteLineColored("  Tip: Run --benchmark <group> for detailed category breakdown.", ConsoleColor.DarkGray);
+        Console.WriteLine();
+    }
+
+    private static ConsoleColor GetBenchmarkScoreColor(int score) => score switch
+    {
+        >= 80 => ConsoleColor.Green,
+        >= 60 => ConsoleColor.Yellow,
+        _ => ConsoleColor.Red
+    };
+}

--- a/src/WinSentinel.Cli/ConsoleFormatter.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.cs
@@ -281,6 +281,7 @@ public static partial class ConsoleFormatter
         WriteHelpEntry("    --policy <action>    ", "Security Policy as Code (export/import/validate/diff)");
         WriteHelpEntry("    --threats            ", "STRIDE threat model from audit findings");
         WriteHelpEntry("    --attack-paths       ", "Kill chain attack path analysis with chokepoints");
+        WriteHelpEntry("    --benchmark [group]  ", "Compare your score against peer groups (home/developer/enterprise/server/all)");
         WriteHelpEntry("    --help, -h           ", "Show this help message");
         WriteHelpEntry("    --version, -v        ", "Show version information");
         Console.WriteLine();

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -42,6 +42,7 @@ return options.Command switch
     CliCommand.ScheduleOptimize => HandleScheduleOptimize(options),
     CliCommand.Digest => await HandleDigest(options),
     CliCommand.AttackPaths => await HandleAttackPaths(options),
+    CliCommand.Benchmark => await HandleBenchmark(options),
     _ => HandleHelp()
 };
 
@@ -2286,6 +2287,159 @@ static async Task<int> HandleAttackPaths(CliOptions options)
     // Save this run to history
     using var historyService = new AuditHistoryService();
     historyService.SaveAuditResult(report);
+
+    return 0;
+}
+
+// ── Peer Benchmark ───────────────────────────────────────────────
+
+static async Task<int> HandleBenchmark(CliOptions options)
+{
+    var engine = BuildEngine(options.ModulesFilter);
+    var sw = Stopwatch.StartNew();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintBanner();
+        Console.WriteLine("  Running audit for peer benchmark comparison...");
+        Console.WriteLine();
+    }
+
+    var progress = options.Quiet || options.Json
+        ? null
+        : new Progress<(string module, int current, int total)>(p =>
+            ConsoleFormatter.PrintProgress(p.module, p.current, p.total));
+
+    var report = await engine.RunFullAuditAsync(progress);
+    sw.Stop();
+
+    if (!options.Quiet && !options.Json)
+    {
+        ConsoleFormatter.PrintProgressDone(engine.Modules.Count, sw.Elapsed);
+    }
+
+    var benchmarkService = new PeerBenchmarkService();
+
+    if (options.BenchmarkAll)
+    {
+        var allResults = benchmarkService.CompareAll(report);
+
+        if (options.Json)
+        {
+            var jsonOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                Converters = { new JsonStringEnumConverter() }
+            };
+            var jsonData = allResults.ToDictionary(
+                kv => kv.Key.ToString(),
+                kv => new
+                {
+                    group = kv.Value.Group.ToString(),
+                    systemScore = kv.Value.SystemOverallScore,
+                    peerMedian = kv.Value.PeerOverallMedian,
+                    percentile = Math.Round(kv.Value.OverallPercentile, 1),
+                    rating = kv.Value.OverallRating,
+                    categoriesAbove = kv.Value.CategoriesAbovePeer,
+                    categoriesAt = kv.Value.CategoriesAtPeer,
+                    categoriesBelow = kv.Value.CategoriesBelowPeer,
+                    suggestedGroup = benchmarkService.SuggestPeerGroup(report).ToString()
+                });
+            var json = JsonSerializer.Serialize(jsonData, jsonOptions);
+            WriteOutput(json, options.OutputFile);
+        }
+        else
+        {
+            ConsoleFormatter.PrintBenchmarkAllSummary(allResults);
+
+            var suggested = benchmarkService.SuggestPeerGroup(report);
+            var orig = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.Write("  Suggested peer group: ");
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.WriteLine(suggested);
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+        }
+
+        return 0;
+    }
+
+    // Single group comparison
+    PeerBenchmarkService.PeerGroup group;
+    if (!string.IsNullOrEmpty(options.BenchmarkGroup))
+    {
+        if (!Enum.TryParse<PeerBenchmarkService.PeerGroup>(options.BenchmarkGroup, true, out group))
+        {
+            ConsoleFormatter.PrintError(
+                $"Unknown peer group: '{options.BenchmarkGroup}'. Available: home, developer, enterprise, server, all");
+            return 3;
+        }
+    }
+    else
+    {
+        // Auto-detect best peer group
+        group = benchmarkService.SuggestPeerGroup(report);
+        if (!options.Quiet && !options.Json)
+        {
+            var orig = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"  Auto-detected peer group: {group} (use --benchmark <group> to override)");
+            Console.ForegroundColor = orig;
+            Console.WriteLine();
+        }
+    }
+
+    var result = benchmarkService.Compare(report, group);
+
+    if (options.Json)
+    {
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        var jsonResult = new
+        {
+            group = result.Group.ToString(),
+            systemScore = result.SystemOverallScore,
+            peerMedian = result.PeerOverallMedian,
+            percentile = Math.Round(result.OverallPercentile, 1),
+            rating = result.OverallRating,
+            categoriesAbove = result.CategoriesAbovePeer,
+            categoriesAt = result.CategoriesAtPeer,
+            categoriesBelow = result.CategoriesBelowPeer,
+            categories = result.Categories.Select(c => new
+            {
+                category = c.Category,
+                score = c.SystemScore,
+                peerMedian = c.PeerMedian,
+                peerP25 = c.PeerP25,
+                peerP75 = c.PeerP75,
+                delta = c.Delta,
+                percentile = Math.Round(c.Percentile, 1),
+                rating = c.Rating.ToString()
+            }),
+            strengths = result.TopStrengths.Select(s => new { s.Category, s.SystemScore, s.PeerMedian, s.Delta }),
+            weaknesses = result.TopWeaknesses.Select(w => new { w.Category, w.SystemScore, w.PeerMedian, w.Delta }),
+            suggestions = result.Suggestions.Select(s => new
+            {
+                category = s.Category,
+                currentScore = s.CurrentScore,
+                peerMedian = s.PeerMedian,
+                gap = s.Gap,
+                recommendation = s.Recommendation,
+                priority = s.Priority.ToString()
+            }),
+            timestamp = DateTimeOffset.UtcNow
+        };
+        var json = JsonSerializer.Serialize(jsonResult, jsonOptions);
+        WriteOutput(json, options.OutputFile);
+    }
+    else
+    {
+        ConsoleFormatter.PrintBenchmarkResult(result);
+    }
 
     return 0;
 }

--- a/tests/WinSentinel.Tests/Cli/CliParserTests.cs
+++ b/tests/WinSentinel.Tests/Cli/CliParserTests.cs
@@ -1164,4 +1164,73 @@ public class CliParserTests
         Assert.Equal(BadgeAction.None, options.BadgeAction);
         Assert.Null(options.BadgeStyle);
     }
+
+    // ── Benchmark Command Tests ──────────────────────────────────
+
+    [Fact]
+    public void Parse_Benchmark_ReturnsBenchmark()
+    {
+        var result = CliParser.Parse(["--benchmark"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Null(result.BenchmarkGroup);
+        Assert.False(result.BenchmarkAll);
+    }
+
+    [Theory]
+    [InlineData("home")]
+    [InlineData("developer")]
+    [InlineData("enterprise")]
+    [InlineData("server")]
+    public void Parse_Benchmark_WithGroup_SetsGroup(string group)
+    {
+        var result = CliParser.Parse(["--benchmark", group]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Equal(group, result.BenchmarkGroup);
+        Assert.False(result.BenchmarkAll);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_All_SetsBenchmarkAll()
+    {
+        var result = CliParser.Parse(["--benchmark", "all"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.True(result.BenchmarkAll);
+        Assert.Null(result.BenchmarkGroup);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_WithJson_SetsJsonFlag()
+    {
+        var result = CliParser.Parse(["--benchmark", "home", "--json"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Equal("home", result.BenchmarkGroup);
+        Assert.True(result.Json);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_WithOutput_SetsOutputFile()
+    {
+        var result = CliParser.Parse(["--benchmark", "developer", "--json", "-o", "bench.json"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Equal("developer", result.BenchmarkGroup);
+        Assert.Equal("bench.json", result.OutputFile);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_GroupNotConsumedAsNextFlag()
+    {
+        // If next arg starts with -, it should NOT be consumed as group
+        var result = CliParser.Parse(["--benchmark", "--json"]);
+        Assert.Equal(CliCommand.Benchmark, result.Command);
+        Assert.Null(result.BenchmarkGroup);
+        Assert.True(result.Json);
+    }
+
+    [Fact]
+    public void Parse_Benchmark_DefaultOptions()
+    {
+        var options = new CliOptions();
+        Assert.Null(options.BenchmarkGroup);
+        Assert.False(options.BenchmarkAll);
+    }
 }


### PR DESCRIPTION
## What

Exposes the existing \PeerBenchmarkService\ through a new \--benchmark\ CLI command, allowing users to compare their security score against peer group benchmarks directly from the command line.

## Usage

\\\ash
# Auto-detect best peer group
winsentinel --benchmark

# Compare against a specific group
winsentinel --benchmark developer

# Compare against all groups at once
winsentinel --benchmark all

# JSON output
winsentinel --benchmark home --json -o benchmark.json
\\\

## Features

- **Auto-detection**: When no group is specified, suggests the best-fitting peer group based on your score
- **Color-coded output**: Strengths in green, weaknesses in red, category breakdown with ratings
- **All-groups summary**: Quick comparison across Home/Developer/Enterprise/Server
- **JSON support**: Full structured output for CI/CD integration
- **Improvement suggestions**: Prioritized recommendations with gap analysis

## Changes

- \CliParser.cs\: Added \Benchmark\ command enum + \--benchmark\ arg parsing with optional group parameter
- \ConsoleFormatter.Benchmark.cs\: New partial class with \PrintBenchmarkResult\ and \PrintBenchmarkAllSummary\
- \ConsoleFormatter.cs\: Added help text for \--benchmark\
- \Program.cs\: Added \HandleBenchmark\ with full audit pipeline, auto-detection, JSON output
- \CliParserTests.cs\: 10 new tests covering all parsing scenarios

## Tests

All 87 tests pass (77 existing + 10 new).