### PR TITLE
refactor: centralize threat response in AgentBrain, remove duplicate logic from ProcessMonitorModule

### DIFF
--- a/src/WinSentinel.Agent/Modules/ProcessMonitorModule.cs
+++ b/src/WinSentinel.Agent/Modules/ProcessMonitorModule.cs
@@ -18,7 +18,6 @@ public class ProcessMonitorModule : IAgentModule
 
     private readonly ILogger<ProcessMonitorModule> _logger;
     private readonly ThreatLog _threatLog;
-    private readonly AgentConfig _config;
     private ManagementEventWatcher? _startWatcher;
     private ManagementEventWatcher? _stopWatcher;
     private CancellationTokenSource? _cts;
@@ -128,7 +127,8 @@ public class ProcessMonitorModule : IAgentModule
     {
         _logger = logger;
         _threatLog = threatLog;
-        _config = config;
+        // config accepted for DI compatibility but not used;
+        // response decisions are centralized in AgentBrain.
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -382,7 +382,7 @@ public class ProcessMonitorModule : IAgentModule
         // Rule 6: Unsigned executable
         CheckUnsignedExecutable(proc, threats);
 
-        // Emit threats
+        // Emit threats — detection only; response is handled centrally by AgentBrain
         foreach (var threat in threats)
         {
             if (!ShouldRateLimit(threat))
@@ -391,8 +391,6 @@ public class ProcessMonitorModule : IAgentModule
                 _logger.LogWarning(
                     "[{Severity}] {Title}: {Desc} (PID {Pid})",
                     threat.Severity, threat.Title, threat.Description, proc.ProcessId);
-
-                HandleResponse(threat, proc);
             }
         }
     }
@@ -616,50 +614,6 @@ public class ProcessMonitorModule : IAgentModule
                               $"Path: {proc.ExecutablePath}",
                 AutoFixable = false
             });
-        }
-    }
-
-    // ── Response Actions ──
-
-    private void HandleResponse(ThreatEvent threat, ProcessInfo proc)
-    {
-        switch (_config.RiskTolerance)
-        {
-            case RiskTolerance.Low:
-                // Aggressive: auto-kill critical threats
-                if (threat.Severity >= ThreatSeverity.Critical && threat.AutoFixable)
-                {
-                    try
-                    {
-                        using var process = Process.GetProcessById(proc.ProcessId);
-                        process.Kill(entireProcessTree: true);
-                        threat.ResponseTaken = $"Auto-killed process PID {proc.ProcessId}";
-                        _logger.LogWarning("Auto-killed suspicious process: {Name} (PID {Pid})",
-                            proc.ProcessName, proc.ProcessId);
-                    }
-                    catch (Exception ex)
-                    {
-                        threat.ResponseTaken = $"Kill failed: {ex.Message}";
-                        _logger.LogWarning(ex, "Failed to kill suspicious process PID {Pid}", proc.ProcessId);
-                    }
-                }
-                else
-                {
-                    threat.ResponseTaken = "Alert sent to UI";
-                }
-                break;
-
-            case RiskTolerance.Medium:
-                // Balanced: alert on everything, suggest fixes
-                threat.ResponseTaken = threat.AutoFixable
-                    ? "Alert sent — fix available"
-                    : "Alert sent — manual review recommended";
-                break;
-
-            case RiskTolerance.High:
-                // Relaxed: log only, no action
-                threat.ResponseTaken = "Logged only (high risk tolerance)";
-                break;
         }
     }
 


### PR DESCRIPTION
## Summary

**ProcessMonitorModule.HandleResponse** duplicated the centralized decision pipeline in **AgentBrain**. When a threat was added to ThreatLog, AgentBrain already picks it up via the \ThreatDetected\ event and processes it through policy evaluation, threat correlation, and AutoRemediator.

The module's \HandleResponse\ bypassed all of that — directly killing processes based on \RiskTolerance\ without consulting:
- Policy rules and custom rules
- User overrides (AlwaysIgnore, AlwaysAutoFix, etc.)
- Threat correlation (might escalate/de-escalate severity)
- AutoRemediator (proper undo tracking, journal recording)

### Problems this caused:
1. **Double-kills** — module kills the process, then AgentBrain tries to kill it again via AutoRemediator
2. **Policy bypass** — module ignores user overrides and custom PolicyRules
3. **Missed correlations** — if the module handles the response, the brain's correlation engine still processes the event but the response is already taken
4. **Inconsistent journal** — module's response not recorded through the brain's journal system

### Changes:
- Removed \HandleResponse\ from ProcessMonitorModule (49 lines deleted)
- Modules are now pure threat detectors: they emit to ThreatLog, period
- All response decisions flow through AgentBrain → ResponsePolicy → AutoRemediator
- Removed unused \_config\ field (was only used by HandleResponse)