### PR TITLE
feat: add --matrix CLI command for scan comparison matrix

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -79,6 +79,9 @@ public class CliOptions
     public string? WhatIfModule { get; set; }
     public string? WhatIfPattern { get; set; }
     public int WhatIfTopN { get; set; } = 5;
+    public int MatrixScans { get; set; } = 5;
+    public string? MatrixModuleFilter { get; set; }
+    public bool MatrixSortByName { get; set; }
 }
 
 public enum CliCommand
@@ -107,6 +110,7 @@ public enum CliCommand
     Digest,
     AttackPaths,
     WhatIf,
+    Matrix,
     Help,
     Version
 }
@@ -484,6 +488,26 @@ public static class CliParser
                     if (!TryConsumeInt(args, ref i, "--whatif-top", 1, 100, out var wiTop, out var wiTopErr))
                     { options.Error = wiTopErr; return options; }
                     options.WhatIfTopN = wiTop;
+                    break;
+
+                case "--matrix":
+                    options.Command = CliCommand.Matrix;
+                    break;
+
+                case "--matrix-scans":
+                    if (!TryConsumeInt(args, ref i, "--matrix-scans", 2, 20, out var mxScans, out var mxScErr))
+                    { options.Error = mxScErr; return options; }
+                    options.MatrixScans = mxScans;
+                    break;
+
+                case "--matrix-module":
+                    if (!TryConsumeArg(args, ref i, "--matrix-module", out var mxMod, out var mxModErr))
+                    { options.Error = mxModErr; return options; }
+                    options.MatrixModuleFilter = mxMod;
+                    break;
+
+                case "--matrix-sort-name":
+                    options.MatrixSortByName = true;
                     break;
 
                 case "--digest-days":

--- a/src/WinSentinel.Cli/ConsoleFormatter.Matrix.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Matrix.cs
@@ -1,0 +1,182 @@
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Cli;
+
+public static partial class ConsoleFormatter
+{
+    /// <summary>
+    /// Print a scan comparison matrix showing per-module scores across multiple scans.
+    /// </summary>
+    public static void PrintScanMatrix(ScanMatrixService.MatrixReport report)
+    {
+        var orig = Console.ForegroundColor;
+
+        Console.WriteLine();
+        WriteLineColored("  ╔══════════════════════════════════════════════╗", ConsoleColor.Cyan);
+        WriteLineColored("  ║       🛡️  Scan Comparison Matrix            ║", ConsoleColor.Cyan);
+        WriteLineColored("  ╚══════════════════════════════════════════════╝", ConsoleColor.Cyan);
+        Console.WriteLine();
+
+        var summary = report.Summary;
+        WriteColored("  Scans: ", ConsoleColor.DarkGray);
+        WriteLineColored($"{summary.TotalScans} ({summary.OldestScan.LocalDateTime:g} → {summary.NewestScan.LocalDateTime:g})", ConsoleColor.White);
+        WriteColored("  Modules: ", ConsoleColor.DarkGray);
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write($"{summary.TotalModules}");
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write("  (");
+        if (summary.ImprovingModules > 0)
+        {
+            WriteColored($"↑{summary.ImprovingModules}", ConsoleColor.Green);
+            Console.Write(" ");
+        }
+        if (summary.StableModules > 0)
+        {
+            WriteColored($"→{summary.StableModules}", ConsoleColor.DarkGray);
+            Console.Write(" ");
+        }
+        if (summary.DecliningModules > 0)
+        {
+            WriteColored($"↓{summary.DecliningModules}", ConsoleColor.Red);
+        }
+        Console.WriteLine(")");
+        Console.WriteLine();
+
+        // Determine column width for module names
+        var maxModuleLen = report.Rows.Count > 0
+            ? Math.Min(22, report.Rows.Max(r => r.Category.Length))
+            : 10;
+        maxModuleLen = Math.Max(maxModuleLen, 10);
+
+        // Header row
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write("  " + "Module".PadRight(maxModuleLen));
+        foreach (var col in report.Columns)
+        {
+            var label = col.Timestamp.LocalDateTime.ToString("MM/dd");
+            Console.Write($"  {label,6}");
+        }
+        Console.Write("    Δ  Trend");
+        Console.WriteLine();
+
+        // Separator
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write("  " + new string('─', maxModuleLen));
+        foreach (var _ in report.Columns)
+            Console.Write("──" + new string('─', 6));
+        Console.Write("──" + new string('─', 4) + "──" + new string('─', 9));
+        Console.WriteLine();
+        Console.ForegroundColor = orig;
+
+        // Data rows
+        foreach (var row in report.Rows)
+        {
+            // Module name
+            var displayName = row.Category.Length > maxModuleLen
+                ? row.Category[..(maxModuleLen - 1)] + "…"
+                : row.Category;
+            Console.Write("  " + displayName.PadRight(maxModuleLen));
+
+            // Score cells
+            foreach (var cell in row.Cells)
+            {
+                if (cell == null)
+                {
+                    Console.ForegroundColor = ConsoleColor.DarkGray;
+                    Console.Write("       —");
+                }
+                else
+                {
+                    Console.ForegroundColor = GetScoreColor(cell.Score);
+                    var marker = cell.CriticalCount > 0 ? "!" : cell.WarningCount > 0 ? "~" : " ";
+                    Console.Write($"  {cell.Score,5}{marker}");
+                }
+            }
+
+            // Net change
+            Console.Write("  ");
+            if (row.NetChange > 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.Write($"{("+" + row.NetChange),4}");
+            }
+            else if (row.NetChange < 0)
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.Write($"{row.NetChange,4}");
+            }
+            else
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write($"{"  0",4}");
+            }
+
+            // Trend
+            Console.Write("  ");
+            switch (row.Trend)
+            {
+                case "Improving":
+                    WriteColored("↑ Better ", ConsoleColor.Green);
+                    break;
+                case "Declining":
+                    WriteColored("↓ Worse  ", ConsoleColor.Red);
+                    break;
+                case "Stable":
+                    WriteColored("→ Stable ", ConsoleColor.DarkGray);
+                    break;
+                default:
+                    WriteColored("? N/A    ", ConsoleColor.DarkGray);
+                    break;
+            }
+
+            Console.WriteLine();
+        }
+
+        // Overall score row
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.Write("  " + new string('─', maxModuleLen));
+        foreach (var _ in report.Columns)
+            Console.Write("──" + new string('─', 6));
+        Console.Write("──" + new string('─', 4) + "──" + new string('─', 9));
+        Console.WriteLine();
+
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write("  " + "OVERALL".PadRight(maxModuleLen));
+        foreach (var col in report.Columns)
+        {
+            Console.ForegroundColor = GetScoreColor(col.OverallScore);
+            Console.Write($"  {col.OverallScore,5} ");
+        }
+
+        // Overall change
+        if (report.Columns.Count >= 2)
+        {
+            var overallDelta = report.Columns[^1].OverallScore - report.Columns[0].OverallScore;
+            Console.Write("  ");
+            Console.ForegroundColor = overallDelta > 0 ? ConsoleColor.Green
+                : overallDelta < 0 ? ConsoleColor.Red : ConsoleColor.DarkGray;
+            var prefix = overallDelta > 0 ? "+" : "";
+            Console.Write($"{prefix + overallDelta,4}");
+        }
+
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+
+        // Legend
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.DarkGray;
+        Console.WriteLine("  Legend: ! = has critical findings  ~ = has warnings  Δ = oldest→newest change");
+        Console.WriteLine("  Options: --matrix-scans N  --matrix-module <filter>  --matrix-sort-name  --json  --csv");
+        Console.ForegroundColor = orig;
+        Console.WriteLine();
+
+        return;
+
+        static ConsoleColor GetScoreColor(int score) => score switch
+        {
+            >= 80 => ConsoleColor.Green,
+            >= 60 => ConsoleColor.Yellow,
+            _ => ConsoleColor.Red,
+        };
+    }
+}

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -43,6 +43,7 @@ return options.Command switch
     CliCommand.Digest => await HandleDigest(options),
     CliCommand.AttackPaths => await HandleAttackPaths(options),
     CliCommand.WhatIf => await HandleWhatIf(options),
+    CliCommand.Matrix => HandleMatrix(options),
     _ => HandleHelp()
 };
 
@@ -2419,5 +2420,84 @@ static async Task<int> HandleWhatIf(CliOptions options)
     using var historyService = new AuditHistoryService();
     historyService.SaveAuditResult(report);
 
+    return 0;
+}
+// -- Scan Comparison Matrix ---------------------------------------------------
+
+static int HandleMatrix(CliOptions options)
+{
+    using var history = new AuditHistoryService();
+    history.EnsureDatabase();
+
+    var runs = history.GetRecentRuns(options.MatrixScans);
+
+    if (runs.Count < 2)
+    {
+        if (options.Json)
+        {
+            WriteOutput("{\"error\": \"Need at least 2 audit runs for a matrix. Run more audits first.\"}", options.OutputFile);
+        }
+        else
+        {
+            ConsoleFormatter.PrintWarning("Need at least 2 audit runs to build a comparison matrix. Run more audits first.");
+        }
+        return 1;
+    }
+
+    // Load module scores for each run
+    for (int i = 0; i < runs.Count; i++)
+    {
+        var fullRun = history.GetRunDetails(runs[i].Id);
+        if (fullRun != null)
+        {
+            runs[i].ModuleScores = fullRun.ModuleScores;
+        }
+    }
+
+    var matrixService = new ScanMatrixService();
+    var matrixOptions = new ScanMatrixService.MatrixOptions
+    {
+        MaxScans = options.MatrixScans,
+        ModuleFilter = options.MatrixModuleFilter,
+        SortByName = options.MatrixSortByName,
+    };
+
+    var report = matrixService.Build(runs, matrixOptions);
+
+    if (report.Columns.Count == 0)
+    {
+        ConsoleFormatter.PrintWarning("No module score data found. Run a full audit (--audit) first.");
+        return 1;
+    }
+
+    if (options.Json)
+    {
+        var json = JsonSerializer.Serialize(report, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter() }
+        });
+        WriteOutput(json, options.OutputFile);
+        return 0;
+    }
+
+    if (options.Csv)
+    {
+        var lines = new List<string>();
+        var header = "Module,Category," + string.Join(",",
+            report.Columns.Select(c => c.Timestamp.LocalDateTime.ToString("MM/dd HH:mm"))) + ",NetChange,Trend";
+        lines.Add(header);
+        foreach (var row in report.Rows)
+        {
+            var cells = string.Join(",", row.Cells.Select(c => c?.Score.ToString() ?? ""));
+            lines.Add($"{row.ModuleName},{row.Category},{cells},{row.NetChange},{row.Trend}");
+        }
+        var csv = string.Join(Environment.NewLine, lines);
+        WriteOutput(csv, options.OutputFile);
+        return 0;
+    }
+
+    ConsoleFormatter.PrintScanMatrix(report);
     return 0;
 }

--- a/src/WinSentinel.Core/Services/ScanMatrixService.cs
+++ b/src/WinSentinel.Core/Services/ScanMatrixService.cs
@@ -1,0 +1,174 @@
+using WinSentinel.Core.Models;
+
+namespace WinSentinel.Core.Services;
+
+/// <summary>
+/// Builds a comparison matrix showing module scores across multiple historical
+/// audit runs. Useful for spotting per-module regressions and improvements at
+/// a glance. Each row is a module; each column is a scan (newest → oldest or
+/// chronological depending on options).
+/// </summary>
+public class ScanMatrixService
+{
+    // ── Result types ─────────────────────────────────────────────────
+
+    /// <summary>A single cell in the matrix (one module × one scan).</summary>
+    public record MatrixCell(
+        int Score,
+        int FindingCount,
+        int CriticalCount,
+        int WarningCount);
+
+    /// <summary>One row of the matrix representing a single module across scans.</summary>
+    public record MatrixRow(
+        string ModuleName,
+        string Category,
+        List<MatrixCell?> Cells,
+        int NetChange,
+        string Trend);
+
+    /// <summary>One column header representing a single scan.</summary>
+    public record MatrixColumn(
+        long RunId,
+        DateTimeOffset Timestamp,
+        int OverallScore,
+        string Grade);
+
+    /// <summary>Summary statistics for the matrix.</summary>
+    public record MatrixSummary(
+        int TotalScans,
+        int TotalModules,
+        int ImprovingModules,
+        int DecliningModules,
+        int StableModules,
+        int BestOverallScore,
+        int WorstOverallScore,
+        DateTimeOffset OldestScan,
+        DateTimeOffset NewestScan);
+
+    /// <summary>Full matrix report.</summary>
+    public record MatrixReport(
+        List<MatrixColumn> Columns,
+        List<MatrixRow> Rows,
+        MatrixSummary Summary);
+
+    // ── Options ──────────────────────────────────────────────────────
+
+    public class MatrixOptions
+    {
+        /// <summary>Max number of scans (columns) to include. Default 5.</summary>
+        public int MaxScans { get; set; } = 5;
+        public string? ModuleFilter { get; set; }
+        public bool SortByName { get; set; }
+    }
+
+    // ── Build ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Build a comparison matrix from audit run records that include
+    /// <see cref="AuditRunRecord.ModuleScores"/>.
+    /// Runs should be provided newest-first (as returned by history service).
+    /// </summary>
+    public MatrixReport Build(List<AuditRunRecord> runs, MatrixOptions? options = null)
+    {
+        options ??= new MatrixOptions();
+
+        // Take the requested number and reverse to chronological
+        var selected = runs
+            .Where(r => r.ModuleScores.Count > 0)
+            .Take(options.MaxScans)
+            .Reverse()
+            .ToList();
+
+        if (selected.Count == 0)
+        {
+            return new MatrixReport(
+                [],
+                [],
+                new MatrixSummary(0, 0, 0, 0, 0, 0, 0, DateTimeOffset.MinValue, DateTimeOffset.MinValue));
+        }
+
+        // Build columns
+        var columns = selected.Select(r => new MatrixColumn(
+            r.Id, r.Timestamp, r.OverallScore, r.Grade)).ToList();
+
+        // Collect all module names across all selected runs
+        var allModules = selected
+            .SelectMany(r => r.ModuleScores)
+            .Select(m => (m.ModuleName, m.Category))
+            .Distinct()
+            .ToList();
+
+        // Apply module filter
+        if (!string.IsNullOrWhiteSpace(options.ModuleFilter))
+        {
+            allModules = allModules
+                .Where(m => m.ModuleName.Contains(options.ModuleFilter, StringComparison.OrdinalIgnoreCase) ||
+                            m.Category.Contains(options.ModuleFilter, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        // Build rows
+        var rows = new List<MatrixRow>();
+        foreach (var (moduleName, category) in allModules)
+        {
+            var cells = new List<MatrixCell?>();
+            foreach (var run in selected)
+            {
+                var modScore = run.ModuleScores
+                    .FirstOrDefault(m => m.ModuleName == moduleName);
+                if (modScore != null)
+                {
+                    cells.Add(new MatrixCell(
+                        modScore.Score,
+                        modScore.FindingCount,
+                        modScore.CriticalCount,
+                        modScore.WarningCount));
+                }
+                else
+                {
+                    cells.Add(null);
+                }
+            }
+
+            // Calculate net change (first non-null to last non-null)
+            var firstScore = cells.FirstOrDefault(c => c != null)?.Score;
+            var lastScore = cells.LastOrDefault(c => c != null)?.Score;
+            var netChange = (firstScore.HasValue && lastScore.HasValue)
+                ? lastScore.Value - firstScore.Value
+                : 0;
+
+            var trend = (firstScore.HasValue && lastScore.HasValue)
+                ? netChange > 2 ? "Improving"
+                    : netChange < -2 ? "Declining"
+                    : "Stable"
+                : "Insufficient";
+
+            rows.Add(new MatrixRow(moduleName, category, cells, netChange, trend));
+        }
+
+        // Sort
+        if (options.SortByName)
+            rows = rows.OrderBy(r => r.ModuleName).ToList();
+        else
+            rows = rows.OrderBy(r => r.NetChange).ToList(); // worst regressions first
+
+        // Summary
+        var improving = rows.Count(r => r.Trend == "Improving");
+        var declining = rows.Count(r => r.Trend == "Declining");
+        var stable = rows.Count(r => r.Trend == "Stable");
+
+        var summary = new MatrixSummary(
+            selected.Count,
+            rows.Count,
+            improving,
+            declining,
+            stable,
+            selected.Max(r => r.OverallScore),
+            selected.Min(r => r.OverallScore),
+            selected.First().Timestamp,
+            selected.Last().Timestamp);
+
+        return new MatrixReport(columns, rows, summary);
+    }
+}

--- a/tests/WinSentinel.Tests/Services/ScanMatrixServiceTests.cs
+++ b/tests/WinSentinel.Tests/Services/ScanMatrixServiceTests.cs
@@ -1,0 +1,239 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+using Xunit;
+
+namespace WinSentinel.Tests.Services;
+
+public class ScanMatrixServiceTests
+{
+    private static AuditRunRecord MakeRun(long id, int overallScore, DateTimeOffset timestamp,
+        params (string module, string category, int score, int findings, int critical, int warnings)[] modules)
+    {
+        var run = new AuditRunRecord
+        {
+            Id = id,
+            OverallScore = overallScore,
+            Grade = overallScore >= 80 ? "A" : overallScore >= 60 ? "B" : "C",
+            Timestamp = timestamp,
+            TotalFindings = modules.Sum(m => m.findings),
+            CriticalCount = modules.Sum(m => m.critical),
+            WarningCount = modules.Sum(m => m.warnings),
+        };
+        foreach (var (module, category, score, findings, critical, warnings) in modules)
+        {
+            run.ModuleScores.Add(new ModuleScoreRecord
+            {
+                RunId = id,
+                ModuleName = module,
+                Category = category,
+                Score = score,
+                FindingCount = findings,
+                CriticalCount = critical,
+                WarningCount = warnings,
+            });
+        }
+        return run;
+    }
+
+    [Fact]
+    public void Build_EmptyRuns_ReturnsEmptyMatrix()
+    {
+        var svc = new ScanMatrixService();
+        var result = svc.Build([]);
+
+        Assert.Empty(result.Columns);
+        Assert.Empty(result.Rows);
+        Assert.Equal(0, result.Summary.TotalScans);
+    }
+
+    [Fact]
+    public void Build_TwoRuns_BuildsCorrectMatrix()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        // Runs provided newest-first
+        var runs = new List<AuditRunRecord>
+        {
+            MakeRun(2, 85, now,
+                ("Firewall", "Firewall", 90, 1, 0, 1),
+                ("Network", "Network", 80, 2, 0, 2)),
+            MakeRun(1, 70, now.AddDays(-7),
+                ("Firewall", "Firewall", 70, 3, 1, 2),
+                ("Network", "Network", 70, 4, 1, 3)),
+        };
+
+        var result = svc.Build(runs);
+
+        Assert.Equal(2, result.Columns.Count);
+        // Columns should be chronological (oldest first)
+        Assert.Equal(1, result.Columns[0].RunId);
+        Assert.Equal(2, result.Columns[1].RunId);
+
+        Assert.Equal(2, result.Rows.Count);
+        Assert.Equal(2, result.Summary.TotalScans);
+        Assert.Equal(2, result.Summary.TotalModules);
+    }
+
+    [Fact]
+    public void Build_DetectsImprovingAndDecliningModules()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        var runs = new List<AuditRunRecord>
+        {
+            MakeRun(2, 80, now,
+                ("Firewall", "Firewall", 90, 1, 0, 1),   // improved from 60
+                ("Network", "Network", 50, 5, 2, 3)),     // declined from 80
+            MakeRun(1, 70, now.AddDays(-7),
+                ("Firewall", "Firewall", 60, 4, 2, 2),
+                ("Network", "Network", 80, 2, 0, 2)),
+        };
+
+        var result = svc.Build(runs);
+
+        var firewall = result.Rows.First(r => r.ModuleName == "Firewall");
+        var network = result.Rows.First(r => r.ModuleName == "Network");
+
+        Assert.Equal(30, firewall.NetChange);
+        Assert.Equal("Improving", firewall.Trend);
+
+        Assert.Equal(-30, network.NetChange);
+        Assert.Equal("Declining", network.Trend);
+
+        // Default sort: worst regressions first
+        Assert.Equal("Network", result.Rows[0].ModuleName);
+        Assert.Equal("Firewall", result.Rows[1].ModuleName);
+
+        Assert.Equal(1, result.Summary.ImprovingModules);
+        Assert.Equal(1, result.Summary.DecliningModules);
+    }
+
+    [Fact]
+    public void Build_SortByName_SortsAlphabetically()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        var runs = new List<AuditRunRecord>
+        {
+            MakeRun(2, 80, now,
+                ("Firewall", "Firewall", 90, 1, 0, 1),
+                ("Accounts", "Accounts", 70, 2, 0, 2)),
+            MakeRun(1, 70, now.AddDays(-7),
+                ("Firewall", "Firewall", 60, 4, 2, 2),
+                ("Accounts", "Accounts", 70, 2, 0, 2)),
+        };
+
+        var result = svc.Build(runs, new ScanMatrixService.MatrixOptions { SortByName = true });
+
+        Assert.Equal("Accounts", result.Rows[0].ModuleName);
+        Assert.Equal("Firewall", result.Rows[1].ModuleName);
+    }
+
+    [Fact]
+    public void Build_ModuleFilter_FiltersCorrectly()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        var runs = new List<AuditRunRecord>
+        {
+            MakeRun(2, 80, now,
+                ("Firewall", "Firewall", 90, 1, 0, 1),
+                ("Network", "Network", 80, 2, 0, 2)),
+            MakeRun(1, 70, now.AddDays(-7),
+                ("Firewall", "Firewall", 60, 4, 2, 2),
+                ("Network", "Network", 70, 4, 1, 3)),
+        };
+
+        var result = svc.Build(runs, new ScanMatrixService.MatrixOptions { ModuleFilter = "fire" });
+
+        Assert.Single(result.Rows);
+        Assert.Equal("Firewall", result.Rows[0].ModuleName);
+    }
+
+    [Fact]
+    public void Build_MissingModule_ShowsNullCell()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        var runs = new List<AuditRunRecord>
+        {
+            MakeRun(2, 80, now,
+                ("Firewall", "Firewall", 90, 1, 0, 1),
+                ("NewModule", "NewModule", 75, 2, 0, 2)),
+            MakeRun(1, 70, now.AddDays(-7),
+                ("Firewall", "Firewall", 60, 4, 2, 2)),
+        };
+
+        var result = svc.Build(runs);
+
+        var newMod = result.Rows.First(r => r.ModuleName == "NewModule");
+        // First column (old run) should be null, second should have score
+        Assert.Null(newMod.Cells[0]);
+        Assert.NotNull(newMod.Cells[1]);
+        Assert.Equal(75, newMod.Cells[1]!.Score);
+    }
+
+    [Fact]
+    public void Build_MaxScans_LimitsColumns()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        var runs = new List<AuditRunRecord>();
+        for (int i = 0; i < 10; i++)
+        {
+            runs.Add(MakeRun(10 - i, 70 + i, now.AddDays(-i),
+                ("Firewall", "Firewall", 70 + i, 1, 0, 1)));
+        }
+
+        var result = svc.Build(runs, new ScanMatrixService.MatrixOptions { MaxScans = 3 });
+
+        Assert.Equal(3, result.Columns.Count);
+        Assert.Equal(3, result.Summary.TotalScans);
+    }
+
+    [Fact]
+    public void Build_StableModule_DetectedCorrectly()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        var runs = new List<AuditRunRecord>
+        {
+            MakeRun(2, 80, now,
+                ("Firewall", "Firewall", 80, 1, 0, 1)),
+            MakeRun(1, 80, now.AddDays(-7),
+                ("Firewall", "Firewall", 80, 1, 0, 1)),
+        };
+
+        var result = svc.Build(runs);
+
+        Assert.Equal("Stable", result.Rows[0].Trend);
+        Assert.Equal(0, result.Rows[0].NetChange);
+        Assert.Equal(1, result.Summary.StableModules);
+    }
+
+    [Fact]
+    public void Build_RunsWithoutModuleScores_AreSkipped()
+    {
+        var svc = new ScanMatrixService();
+        var now = DateTimeOffset.UtcNow;
+
+        var runs = new List<AuditRunRecord>
+        {
+            new() { Id = 2, OverallScore = 80, Timestamp = now, Grade = "A" },  // no module scores
+            MakeRun(1, 70, now.AddDays(-7),
+                ("Firewall", "Firewall", 70, 3, 1, 2)),
+        };
+
+        var result = svc.Build(runs);
+
+        // Only one run has module scores, so only 1 column
+        Assert.Single(result.Columns);
+    }
+}


### PR DESCRIPTION
## Scan Comparison Matrix

Adds a new \--matrix\ CLI command that displays a module-by-module score grid across multiple historical audit scans.

### What it does
Shows each module's score at each scan point, with color-coded cells, critical/warning indicators, net change deltas, and trend detection (Improving/Declining/Stable).

### CLI Options
- \--matrix\ — Show the comparison matrix
- \--matrix-scans N\ — Number of scans to include (default 5, max 20)
- \--matrix-module <filter>\ — Filter modules by name
- \--matrix-sort-name\ — Sort by module name instead of worst-regression-first
- \--json\ / \--csv\ — Machine-readable output

### Example output
\\\
  Module          03/10  03/12  03/14  03/16    Δ  Trend
  ──────────────────────────────────────────────────────
  Network            80     75     60     55!  -25  ↓ Worse
  Accounts           70     70     72     72     +2  → Stable
  Firewall           60     70     80     90~  +30  ↑ Better
  ──────────────────────────────────────────────────────
  OVERALL            70     72     71     72    +2
\\\

### Tests
9 unit tests covering empty input, two-run matrix, trend detection, sorting, filtering, missing modules, column limiting, stable detection, and runs-without-scores skipping.