### PR TITLE
security: add InputSanitizer safety check to chat FixCommand

### DIFF
--- a/src/WinSentinel.Agent/Services/Commands/FixCommand.cs
+++ b/src/WinSentinel.Agent/Services/Commands/FixCommand.cs
@@ -44,9 +44,18 @@ public sealed class FixCommand : ChatCommandBase
         sb.AppendLine($"🔧 **Fixing {fixable.Count} issues...**");
         sb.AppendLine();
 
-        int succeeded = 0, failed = 0;
+        int succeeded = 0, failed = 0, blocked = 0;
         foreach (var finding in fixable)
         {
+            // Safety check: block dangerous commands (matches AutoRemediator & IpcServer)
+            var dangerReason = Core.Helpers.InputSanitizer.CheckDangerousCommand(finding.FixCommand!);
+            if (dangerReason != null)
+            {
+                sb.AppendLine($"  🚫 {finding.Title}: blocked by safety check ({dangerReason})");
+                blocked++;
+                continue;
+            }
+
             var result = await fixEngine.ExecuteFixAsync(finding);
             if (result.Success)
             {
@@ -61,7 +70,8 @@ public sealed class FixCommand : ChatCommandBase
         }
 
         sb.AppendLine();
-        sb.AppendLine($"**Results:** {succeeded} fixed, {failed} failed");
+        sb.AppendLine($"**Results:** {succeeded} fixed, {failed} failed" +
+            (blocked > 0 ? $", {blocked} blocked by safety check" : ""));
 
         return new ChatResponsePayload
         {
@@ -109,6 +119,15 @@ public sealed class FixCommand : ChatCommandBase
                 $"⚠️ \"{match.Title}\" doesn't have an automated fix.\n" +
                 (match.Remediation != null ? $"💡 Manual fix: {match.Remediation}" : ""),
                 ChatResponseCategory.General);
+        }
+
+        // Safety check: block dangerous commands (matches AutoRemediator & IpcServer)
+        var dangerReason = Core.Helpers.InputSanitizer.CheckDangerousCommand(match.FixCommand);
+        if (dangerReason != null)
+        {
+            return SimpleResponse(
+                $"🚫 **Blocked: {match.Title}**\nFix command rejected by safety check: {dangerReason}",
+                ChatResponseCategory.Error);
         }
 
         var fixEngine = new FixEngine();


### PR DESCRIPTION
## Security Fix

The chat \FixCommand\ (\ix <target>\ and \ix all\) bypassed the \InputSanitizer.CheckDangerousCommand()\ safety check that both \AutoRemediator.ExecuteFixCommand\ and \IpcServer.HandleRunFixAsync\ enforce before executing fix commands.

### Impact
A crafted finding with a malicious \FixCommand\ (e.g. containing format-disk or registry-wipe patterns) would be **blocked** via IPC or auto-remediation, but would **execute unchecked** when triggered through the chat interface.

### Changes
- **\HandleFixAllAsync\**: Checks each finding's FixCommand via \InputSanitizer.CheckDangerousCommand()\ before execution. Blocked commands are counted and reported separately in the results summary.
- **\HandleFixAsync\**: Checks the matched finding's FixCommand before execution. Returns a clear error message when blocked.

This brings the chat fix path to parity with the other two execution paths (\AutoRemediator\ and \IpcServer\).