### PR TITLE
feat: add Collection Detector (MITRE ATT&CK TA0009)

### DIFF
--- a/src/WinSentinel.Cli/CliParser.cs
+++ b/src/WinSentinel.Cli/CliParser.cs
@@ -359,6 +359,12 @@ public class CliOptions
     public int ImpactTop { get; set; } = 20;
     public string ImpactFormat { get; set; } = "text";
     public string? ImpactSeverityFilter { get; set; }
+
+    // Collection options
+    public int CollectionDays { get; set; } = 90;
+    public int CollectionTop { get; set; } = 20;
+    public string CollectionFormat { get; set; } = "text";
+    public string? CollectionSeverityFilter { get; set; }
 }
 
 public enum CliCommand
@@ -463,6 +469,7 @@ public enum CliCommand
     Execution,
     C2,
     Impact,
+    Collection,
     Help,
     Version
 }
@@ -3018,6 +3025,34 @@ public static class CliParser
                     if (!TryConsumeArg(args, ref i, "--impact-severity", out var impSevVal, out var impSevErr))
                     { options.Error = impSevErr; return options; }
                     options.ImpactSeverityFilter = impSevVal;
+                    break;
+                case "--collection":
+                case "collection":
+                case "collect":
+                case "data-collection":
+                    options.Command = CliCommand.Collection;
+                    break;
+                case "--collection-days":
+                    if (!TryConsumeArg(args, ref i, "--collection-days", out var collDaysVal, out var collDaysErr))
+                    { options.Error = collDaysErr; return options; }
+                    if (int.TryParse(collDaysVal, out var collDaysInt))
+                        options.CollectionDays = Math.Clamp(collDaysInt, 7, 365);
+                    break;
+                case "--collection-top":
+                    if (!TryConsumeArg(args, ref i, "--collection-top", out var collTopVal, out var collTopErr))
+                    { options.Error = collTopErr; return options; }
+                    if (int.TryParse(collTopVal, out var collTopInt))
+                        options.CollectionTop = Math.Clamp(collTopInt, 1, 50);
+                    break;
+                case "--collection-format":
+                    if (!TryConsumeArg(args, ref i, "--collection-format", out var collFmtVal, out var collFmtErr))
+                    { options.Error = collFmtErr; return options; }
+                    options.CollectionFormat = collFmtVal;
+                    break;
+                case "--collection-severity":
+                    if (!TryConsumeArg(args, ref i, "--collection-severity", out var collSevVal, out var collSevErr))
+                    { options.Error = collSevErr; return options; }
+                    options.CollectionSeverityFilter = collSevVal;
                     break;
                 case "--threat-dna-days":
                     if (!TryConsumeArg(args, ref i, "--threat-dna-days", out var tdDaysVal, out var tdDaysErr))

--- a/src/WinSentinel.Cli/ConsoleFormatter.Collection.cs
+++ b/src/WinSentinel.Cli/ConsoleFormatter.Collection.cs
@@ -1,0 +1,196 @@
+namespace WinSentinel.Cli;
+
+using WinSentinel.Core.Models;
+
+public static partial class ConsoleFormatter
+{
+    public static void PrintCollection(CollectionReport report, CliOptions options)
+    {
+        var original = Console.ForegroundColor;
+
+        // Header
+        Console.WriteLine();
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("  ╔══════════════════════════════════════════════════════════╗");
+        Console.WriteLine("  ║   📋  COLLECTION DETECTOR — Data Harvesting Analysis    ║");
+        Console.WriteLine("  ╚══════════════════════════════════════════════════════════╝");
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+
+        // Threat Score Gauge
+        Console.Write("  Threat Score: ");
+        var scoreColor = report.ThreatScore switch
+        {
+            >= 80 => ConsoleColor.DarkRed,
+            >= 60 => ConsoleColor.Red,
+            >= 40 => ConsoleColor.Yellow,
+            >= 20 => ConsoleColor.DarkYellow,
+            _ => ConsoleColor.Green
+        };
+        Console.ForegroundColor = scoreColor;
+        var filled = (int)(report.ThreatScore / 5);
+        var empty = 20 - filled;
+        Console.Write($"[{new string('█', filled)}{new string('░', empty)}] {report.ThreatScore:F0}/100 ({report.ThreatLevel})");
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+        Console.WriteLine();
+
+        // Summary Stats
+        Console.Write("  Events Processed: ");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.Write($"{report.EventsProcessed}");
+        Console.ForegroundColor = original;
+        Console.Write("  |  Collection Activities: ");
+        Console.ForegroundColor = report.CollectionActivitiesDetected > 0 ? ConsoleColor.Red : ConsoleColor.Green;
+        Console.Write($"{report.CollectionActivitiesDetected}");
+        Console.ForegroundColor = original;
+        Console.Write("  |  Days Analyzed: ");
+        Console.ForegroundColor = ConsoleColor.White;
+        Console.WriteLine($"{report.DaysAnalyzed}");
+        Console.WriteLine();
+
+        // Severity Breakdown
+        Console.WriteLine("  Severity Breakdown:");
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.Write($"    High/Critical: {report.HighSeverityCount}");
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Write($"  Medium: {report.MediumSeverityCount}");
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine($"  Low: {report.LowSeverityCount}");
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+
+        // Top Collection Events
+        if (report.Events.Count > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine("  ── Collection Events ────────────────────────────────────");
+            Console.ForegroundColor = original;
+            Console.WriteLine();
+
+            var topCount = options.CollectionTop > 0 ? options.CollectionTop : 20;
+            var events = report.Events.AsEnumerable();
+
+            if (!string.IsNullOrEmpty(options.CollectionSeverityFilter))
+            {
+                events = events.Where(e =>
+                    e.Severity.Equals(options.CollectionSeverityFilter, StringComparison.OrdinalIgnoreCase));
+            }
+
+            var top = events.OrderByDescending(e => e.Confidence).Take(topCount);
+            foreach (var ev in top)
+            {
+                var sevColor = ev.Severity switch
+                {
+                    "Critical" => ConsoleColor.DarkRed,
+                    "High" => ConsoleColor.Red,
+                    "Medium" => ConsoleColor.Yellow,
+                    _ => ConsoleColor.Gray
+                };
+
+                Console.Write("    ");
+                Console.ForegroundColor = sevColor;
+                Console.Write($"[{ev.Severity,-8}]");
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write($" {ev.Technique}");
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write($" ({ev.TechniqueId})");
+                Console.ForegroundColor = original;
+                Console.Write($"  Conf: ");
+                Console.ForegroundColor = ev.Confidence >= 0.8 ? ConsoleColor.Red : ConsoleColor.Yellow;
+                Console.Write($"{ev.Confidence:P0}");
+                Console.ForegroundColor = original;
+                Console.WriteLine();
+
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine($"           {ev.Description}");
+                if (!string.IsNullOrEmpty(ev.TargetData))
+                    Console.WriteLine($"           → Target: {ev.TargetData}");
+                Console.ForegroundColor = original;
+                Console.WriteLine();
+            }
+        }
+
+        // Technique Breakdown
+        if (report.Techniques.Count > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine("  ── Techniques Detected ──────────────────────────────────");
+            Console.ForegroundColor = original;
+            Console.WriteLine();
+
+            foreach (var tech in report.Techniques)
+            {
+                Console.Write("    ");
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write($"{tech.TechniqueName,-30}");
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write($" [{tech.TechniqueId}]");
+                Console.ForegroundColor = original;
+                Console.WriteLine($"  Events: {tech.EventCount}  Severity: {tech.Severity}");
+            }
+            Console.WriteLine();
+        }
+
+        // Campaigns
+        if (report.Campaigns.Count > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine("  ── Collection Campaigns ─────────────────────────────────");
+            Console.ForegroundColor = original;
+            Console.WriteLine();
+
+            foreach (var camp in report.Campaigns)
+            {
+                Console.Write("    ");
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.Write($"⚠ {camp.CampaignId}");
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write($"  Source: {camp.SourceProcess}");
+                Console.ForegroundColor = original;
+                Console.WriteLine($"  Techniques: {camp.TechniquesUsed.Count}  Events: {camp.EventCount}");
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine($"      Techniques: {string.Join(", ", camp.TechniquesUsed)}");
+                Console.ForegroundColor = original;
+                Console.WriteLine();
+            }
+        }
+
+        // Stats
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("  ── Statistics ───────────────────────────────────────────");
+        Console.ForegroundColor = original;
+        Console.WriteLine();
+        Console.WriteLine($"    Techniques Detected:     {report.Stats.TotalTechniquesDetected}");
+        Console.WriteLine($"    Unique Processes:        {report.Stats.UniqueProcesses}");
+        Console.WriteLine($"    Off-Hours Activity:      {report.Stats.OffHoursActivities}");
+        Console.WriteLine($"    High Volume Collections: {report.Stats.HighVolumeCollections}");
+        Console.WriteLine($"    Automated Collection:    {report.Stats.AutomatedCollectionCount}");
+        Console.WriteLine($"    Sensitive Data Targets:  {report.Stats.SensitiveDataTargets}");
+        Console.WriteLine();
+
+        // Recommendations
+        if (report.Recommendations.Count > 0)
+        {
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine("  ── Recommendations ─────────────────────────────────────");
+            Console.ForegroundColor = original;
+            Console.WriteLine();
+
+            foreach (var rec in report.Recommendations.OrderBy(r => r.Priority))
+            {
+                Console.Write($"    {rec.Priority}. ");
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write($"[{rec.Category}] {rec.Title}");
+                Console.ForegroundColor = original;
+                Console.WriteLine();
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine($"       {rec.Description}");
+                Console.ForegroundColor = original;
+                Console.WriteLine();
+            }
+        }
+
+        Console.ForegroundColor = original;
+    }
+}

--- a/src/WinSentinel.Cli/Program.cs
+++ b/src/WinSentinel.Cli/Program.cs
@@ -119,6 +119,7 @@ return options.Command switch
     CliCommand.Execution => await HandleExecution(options),
     CliCommand.C2 => await HandleC2(options),
     CliCommand.Impact => await HandleImpact(options),
+    CliCommand.Collection => await HandleCollection(options),
     _ => HandleHelp()
 };
 
@@ -8601,7 +8602,7 @@ static async Task<int> HandleC2(CliOptions options)
     };
 }
 
-// ── Impact Detection ──────────────────────────────────────────────────
+// ===== Impact Detection =====
 
 static async Task<int> HandleImpact(CliOptions options)
 {
@@ -8622,6 +8623,32 @@ static async Task<int> HandleImpact(CliOptions options)
     ConsoleFormatter.PrintImpactReport(impactReport, options.ImpactFormat);
 
     return impactReport.ThreatScore switch
+    {
+        >= 70 => 2,
+        >= 40 => 1,
+        _ => 0
+    };
+}
+
+static async Task<int> HandleCollection(CliOptions options)
+{
+    var (report, engine, elapsed) = await RunAuditAsync(options, suppressOutput: options.Quiet,
+        bannerMessage: "Running audit for collection activity detection...");
+
+    var history = new AuditHistoryService();
+    var detector = new CollectionDetector(history);
+    var collectionReport = detector.Detect(report, options.CollectionDays);
+
+    if (options.Json)
+    {
+        var jsonOpts = new JsonSerializerOptions { WriteIndented = true, Converters = { new JsonStringEnumConverter() } };
+        OutputHelper.WriteOutput(JsonSerializer.Serialize(collectionReport, jsonOpts), options.OutputFile);
+        return 0;
+    }
+
+    ConsoleFormatter.PrintCollection(collectionReport, options);
+
+    return collectionReport.ThreatScore switch
     {
         >= 70 => 2,
         >= 40 => 1,

--- a/src/WinSentinel.Core/Models/CollectionModels.cs
+++ b/src/WinSentinel.Core/Models/CollectionModels.cs
@@ -1,0 +1,179 @@
+namespace WinSentinel.Core.Models;
+
+/// <summary>
+/// Full collection activity detection report.
+/// MITRE ATT&amp;CK: TA0009 (Collection)
+/// </summary>
+public class CollectionReport
+{
+    /// <summary>When this analysis was generated.</summary>
+    public DateTimeOffset GeneratedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Days of history analyzed.</summary>
+    public int DaysAnalyzed { get; set; }
+
+    /// <summary>Total events processed.</summary>
+    public int EventsProcessed { get; set; }
+
+    /// <summary>Total collection activities detected.</summary>
+    public int CollectionActivitiesDetected { get; set; }
+
+    /// <summary>High severity count.</summary>
+    public int HighSeverityCount { get; set; }
+
+    /// <summary>Medium severity count.</summary>
+    public int MediumSeverityCount { get; set; }
+
+    /// <summary>Low severity count.</summary>
+    public int LowSeverityCount { get; set; }
+
+    /// <summary>Overall threat score (0-100, higher = worse).</summary>
+    public double ThreatScore { get; set; }
+
+    /// <summary>Threat level classification.</summary>
+    public string ThreatLevel { get; set; } = "Minimal";
+
+    /// <summary>Detected collection events.</summary>
+    public List<CollectionEvent> Events { get; set; } = new();
+
+    /// <summary>Aggregated technique breakdown.</summary>
+    public List<CollectionTechnique> Techniques { get; set; } = new();
+
+    /// <summary>Recommendations.</summary>
+    public List<CollectionRecommendation> Recommendations { get; set; } = new();
+
+    /// <summary>Summary statistics.</summary>
+    public CollectionStats Stats { get; set; } = new();
+
+    /// <summary>Detected collection campaigns.</summary>
+    public List<CollectionCampaign> Campaigns { get; set; } = new();
+}
+
+/// <summary>
+/// Individual collection activity event.
+/// </summary>
+public class CollectionEvent
+{
+    /// <summary>When the event occurred.</summary>
+    public DateTimeOffset Timestamp { get; set; }
+
+    /// <summary>Technique name.</summary>
+    public string Technique { get; set; } = string.Empty;
+
+    /// <summary>MITRE ATT&amp;CK technique ID.</summary>
+    public string TechniqueId { get; set; } = string.Empty;
+
+    /// <summary>Description of the collection indicator.</summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Source process or module.</summary>
+    public string SourceProcess { get; set; } = string.Empty;
+
+    /// <summary>Target data being collected.</summary>
+    public string TargetData { get; set; } = string.Empty;
+
+    /// <summary>Severity level.</summary>
+    public string Severity { get; set; } = "Medium";
+
+    /// <summary>Detection confidence (0.0-1.0).</summary>
+    public double Confidence { get; set; }
+
+    /// <summary>Context indicators that triggered detection.</summary>
+    public List<string> ContextIndicators { get; set; } = new();
+
+    /// <summary>Risk factors that boosted severity.</summary>
+    public List<string> RiskFactors { get; set; } = new();
+}
+
+/// <summary>
+/// Aggregated collection technique information.
+/// </summary>
+public class CollectionTechnique
+{
+    /// <summary>Technique name.</summary>
+    public string TechniqueName { get; set; } = string.Empty;
+
+    /// <summary>MITRE technique ID.</summary>
+    public string TechniqueId { get; set; } = string.Empty;
+
+    /// <summary>Number of events using this technique.</summary>
+    public int EventCount { get; set; }
+
+    /// <summary>First seen timestamp.</summary>
+    public DateTimeOffset FirstSeen { get; set; }
+
+    /// <summary>Last seen timestamp.</summary>
+    public DateTimeOffset LastSeen { get; set; }
+
+    /// <summary>Technique severity.</summary>
+    public string Severity { get; set; } = "Medium";
+}
+
+/// <summary>
+/// Recommendation for mitigating collection activity risk.
+/// </summary>
+public class CollectionRecommendation
+{
+    /// <summary>Priority (1=highest).</summary>
+    public int Priority { get; set; }
+
+    /// <summary>Category of recommendation.</summary>
+    public string Category { get; set; } = string.Empty;
+
+    /// <summary>Short title.</summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Detailed description.</summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Related MITRE technique.</summary>
+    public string MitreTechnique { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Summary statistics for collection analysis.
+/// </summary>
+public class CollectionStats
+{
+    /// <summary>Total distinct techniques detected.</summary>
+    public int TotalTechniquesDetected { get; set; }
+
+    /// <summary>Unique source processes.</summary>
+    public int UniqueProcesses { get; set; }
+
+    /// <summary>Collection activities during off-hours.</summary>
+    public int OffHoursActivities { get; set; }
+
+    /// <summary>High volume collection events.</summary>
+    public int HighVolumeCollections { get; set; }
+
+    /// <summary>Automated collection events.</summary>
+    public int AutomatedCollectionCount { get; set; }
+
+    /// <summary>Events targeting sensitive data.</summary>
+    public int SensitiveDataTargets { get; set; }
+}
+
+/// <summary>
+/// Detected collection campaign (multiple techniques from same source).
+/// </summary>
+public class CollectionCampaign
+{
+    /// <summary>Campaign identifier.</summary>
+    public string CampaignId { get; set; } = string.Empty;
+
+    /// <summary>Source process driving the campaign.</summary>
+    public string SourceProcess { get; set; } = string.Empty;
+
+    /// <summary>Techniques used in this campaign.</summary>
+    public List<string> TechniquesUsed { get; set; } = new();
+
+    /// <summary>Total events in this campaign.</summary>
+    public int EventCount { get; set; }
+
+    /// <summary>Campaign severity.</summary>
+    public string Severity { get; set; } = "High";
+
+    /// <summary>Campaign confidence.</summary>
+    public double Confidence { get; set; }
+}

--- a/src/WinSentinel.Core/Services/CollectionDetector.cs
+++ b/src/WinSentinel.Core/Services/CollectionDetector.cs
@@ -1,0 +1,505 @@
+namespace WinSentinel.Core.Services;
+
+using WinSentinel.Core.Models;
+
+/// <summary>
+/// Collection Detector — autonomous detection of data collection patterns
+/// across security findings. Identifies screen capture, clipboard access,
+/// keylogging, input capture, data staging, email collection, automated
+/// collection, and archive creation for exfiltration preparation.
+///
+/// MITRE ATT&amp;CK: TA0009 (Collection)
+/// Techniques: T1113, T1115, T1056.001, T1056.002, T1056.003, T1056.004,
+/// T1074.001, T1074.002, T1114.001, T1114.002, T1119, T1560.001
+/// </summary>
+public sealed class CollectionDetector
+{
+    private readonly AuditHistoryService _history;
+
+    private const int OffHoursStart = 22;
+    private const int OffHoursEnd = 6;
+
+    private sealed record TechniqueSignature(
+        string Name, string TechniqueId, string[] Keywords, double BaseConfidence);
+
+    private static readonly List<TechniqueSignature> Signatures = new()
+    {
+        new("Screen Capture", "T1113",
+            new[] { "screenshot", "screen capture", "printscreen", "screen grab", "display capture", "snipping", "screen record", "bitblt capture" }, 0.80),
+        new("Clipboard Data", "T1115",
+            new[] { "clipboard", "paste data", "clipboard monitor", "clipboard capture", "copy paste intercept", "clipboard hook", "getclipboarddata" }, 0.75),
+        new("Keylogging", "T1056.001",
+            new[] { "keylog", "keystroke", "key capture", "input capture", "keyboard hook", "key monitor", "setwindowshookex", "rawinput keyboard", "getkeystate" }, 0.85),
+        new("GUI Input Capture", "T1056.002",
+            new[] { "gui capture", "input box", "credential dialog", "fake prompt", "gui hook", "fake login", "phishing dialog", "credential popup" }, 0.80),
+        new("Web Portal Capture", "T1056.003",
+            new[] { "web portal", "form capture", "browser credential", "form grab", "web input", "browser hook", "form inject", "web keylog" }, 0.75),
+        new("Credential API Hooking", "T1056.004",
+            new[] { "credential api", "lsass hook", "api hook credential", "sspi hook", "credentialprovider", "credential intercept", "auth hook" }, 0.90),
+        new("Local Data Staging", "T1074.001",
+            new[] { "local staging", "staged data", "temp archive", "staging folder", "data collection folder", "staging directory", "local collect" }, 0.70),
+        new("Remote Data Staging", "T1074.002",
+            new[] { "remote staging", "network share staging", "smb staging", "shared drive staging", "remote collect", "unc staging", "network stage" }, 0.75),
+        new("Local Email Collection", "T1114.001",
+            new[] { "local email", "pst file", "ost file", "email archive", "mailbox export", "outlook data", "email dump", "mail spool" }, 0.80),
+        new("Remote Email Collection", "T1114.002",
+            new[] { "remote email", "exchange harvest", "owa scrape", "email forward rule", "mailbox access", "exchange impersonation", "email intercept" }, 0.85),
+        new("Automated Collection", "T1119",
+            new[] { "automated collection", "scripted harvest", "bulk collect", "mass data gather", "auto-scrape", "scheduled collect", "auto harvest", "systematic collection" }, 0.80),
+        new("Archive via Utility", "T1560.001",
+            new[] { "archive collected", "7zip", "winrar", "compress data", "zip before exfil", "tar archive", "rar archive", "makecab", "compact archive" }, 0.75),
+    };
+
+    /// <summary>Known collection tools.</summary>
+    private static readonly string[] KnownTools =
+    {
+        "lazagne", "mimikatz", "keyscan", "hooker", "powersploit", "empire",
+        "meterpreter", "cobaltstrike", "rubeus", "sharpweb", "seatbelt",
+        "snaffler", "sharphound", "bloodhound", "mailsniper", "ruler",
+        "pspy", "screen capture tool", "keylogger"
+    };
+
+    /// <summary>Sensitive data target indicators.</summary>
+    private static readonly string[] SensitiveTargets =
+    {
+        "email", "credential", "password", "financial", "bank", "ssn",
+        "credit card", "personal", "confidential", "secret", "private key",
+        "certificate", "token", "api key", "database", "patient", "hipaa"
+    };
+
+    /// <summary>High volume indicators.</summary>
+    private static readonly string[] VolumeIndicators =
+    {
+        "bulk", "mass", "large", "all files", "entire", "complete",
+        "recursive", "sweep", "comprehensive", "full scan", "gigabyte"
+    };
+
+    /// <summary>Automation indicators.</summary>
+    private static readonly string[] AutomationIndicators =
+    {
+        "script", "scheduled", "automated", "cron", "task scheduler",
+        "powershell", "batch", "loop", "interval", "periodic", "recurring"
+    };
+
+    public CollectionDetector(AuditHistoryService history) => _history = history;
+
+    /// <summary>Run collection activity detection against the current security report.</summary>
+    public CollectionReport Detect(SecurityReport report, int historyDays = 90)
+    {
+        var runs = _history.GetHistory(historyDays);
+        var findings = report.Results
+            .SelectMany(m => m.Findings.Select(f => (Finding: f, Module: m.ModuleName)))
+            .ToList();
+
+        var result = new CollectionReport
+        {
+            DaysAnalyzed = historyDays,
+            EventsProcessed = findings.Count
+        };
+
+        var events = new List<CollectionEvent>();
+
+        // Detect from current findings
+        foreach (var (finding, module) in findings)
+        {
+            var detected = DetectCollection(finding, module);
+            events.AddRange(detected);
+        }
+
+        // Scan historical findings
+        foreach (var run in runs)
+        {
+            foreach (var fr in run.Findings)
+            {
+                var finding = new Finding
+                {
+                    Title = fr.Title,
+                    Description = fr.Description,
+                    Category = fr.ModuleName
+                };
+                var detected = DetectCollection(finding, fr.ModuleName);
+                events.AddRange(detected);
+            }
+        }
+
+        result.Events = events
+            .OrderByDescending(e => e.Confidence)
+            .ThenByDescending(e => e.Timestamp)
+            .ToList();
+
+        result.CollectionActivitiesDetected = events.Count;
+        result.HighSeverityCount = events.Count(e => e.Severity == "High" || e.Severity == "Critical");
+        result.MediumSeverityCount = events.Count(e => e.Severity == "Medium");
+        result.LowSeverityCount = events.Count(e => e.Severity == "Low");
+
+        // Aggregate techniques
+        result.Techniques = events
+            .GroupBy(e => e.TechniqueId)
+            .Select(g => new CollectionTechnique
+            {
+                TechniqueName = g.First().Technique,
+                TechniqueId = g.Key,
+                EventCount = g.Count(),
+                FirstSeen = g.Min(e => e.Timestamp),
+                LastSeen = g.Max(e => e.Timestamp),
+                Severity = g.Any(e => e.Severity == "Critical") ? "Critical" :
+                           g.Any(e => e.Severity == "High") ? "High" :
+                           g.Any(e => e.Severity == "Medium") ? "Medium" : "Low"
+            })
+            .OrderByDescending(t => t.EventCount)
+            .ToList();
+
+        // Detect campaigns (3+ techniques from same source process)
+        result.Campaigns = DetectCampaigns(events);
+
+        // Calculate stats
+        result.Stats = CalculateStats(events);
+
+        // Calculate threat score
+        result.ThreatScore = CalculateThreatScore(events, result.Campaigns);
+        result.ThreatLevel = result.ThreatScore switch
+        {
+            >= 80 => "Critical",
+            >= 60 => "High",
+            >= 40 => "Moderate",
+            >= 20 => "Low",
+            _ => "Minimal"
+        };
+
+        // Generate recommendations
+        result.Recommendations = GenerateRecommendations(events, result.Techniques);
+
+        return result;
+    }
+
+    private List<CollectionEvent> DetectCollection(Finding finding, string module)
+    {
+        var events = new List<CollectionEvent>();
+        var text = $"{finding.Title} {finding.Description}".ToLowerInvariant();
+
+        foreach (var sig in Signatures)
+        {
+            var matchedKeywords = sig.Keywords
+                .Where(k => text.Contains(k, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (matchedKeywords.Count == 0) continue;
+
+            var confidence = sig.BaseConfidence;
+            var riskFactors = new List<string>();
+            var contextIndicators = new List<string>(matchedKeywords);
+
+            // Check for known tools
+            var toolMatch = KnownTools.FirstOrDefault(t =>
+                text.Contains(t, StringComparison.OrdinalIgnoreCase));
+            if (toolMatch != null)
+            {
+                confidence = Math.Min(1.0, confidence + 0.15);
+                riskFactors.Add($"Known tool: {toolMatch}");
+            }
+
+            // Check for sensitive targets
+            var sensitiveMatch = SensitiveTargets
+                .Where(s => text.Contains(s, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (sensitiveMatch.Count > 0)
+            {
+                confidence = Math.Min(1.0, confidence + 0.05 * sensitiveMatch.Count);
+                riskFactors.Add($"Sensitive target: {string.Join(", ", sensitiveMatch)}");
+            }
+
+            // Check for high volume
+            var volumeMatch = VolumeIndicators
+                .Any(v => text.Contains(v, StringComparison.OrdinalIgnoreCase));
+            if (volumeMatch)
+            {
+                confidence = Math.Min(1.0, confidence + 0.05);
+                riskFactors.Add("High volume indicators");
+            }
+
+            // Check for automation
+            var autoMatch = AutomationIndicators
+                .Any(a => text.Contains(a, StringComparison.OrdinalIgnoreCase));
+            if (autoMatch)
+            {
+                confidence = Math.Min(1.0, confidence + 0.05);
+                riskFactors.Add("Automation indicators");
+            }
+
+            // Off-hours detection
+            var hour = DateTimeOffset.UtcNow.Hour;
+            var isOffHours = hour >= OffHoursStart || hour < OffHoursEnd;
+            if (isOffHours)
+            {
+                confidence = Math.Min(1.0, confidence + 0.05);
+                riskFactors.Add("Off-hours activity");
+            }
+
+            // Determine severity based on confidence + risk factors
+            var severity = confidence switch
+            {
+                >= 0.90 => riskFactors.Count >= 2 ? "Critical" : "High",
+                >= 0.75 => riskFactors.Count >= 2 ? "High" : "Medium",
+                >= 0.60 => "Medium",
+                _ => "Low"
+            };
+
+            // Extract source process hint
+            var sourceProcess = ExtractProcessHint(text) ?? module;
+
+            // Extract target data hint
+            var targetData = ExtractTargetHint(text, sig.Name);
+
+            events.Add(new CollectionEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Technique = sig.Name,
+                TechniqueId = sig.TechniqueId,
+                Description = finding.Title,
+                SourceProcess = sourceProcess,
+                TargetData = targetData,
+                Severity = severity,
+                Confidence = Math.Round(confidence, 3),
+                ContextIndicators = contextIndicators,
+                RiskFactors = riskFactors
+            });
+        }
+
+        return events;
+    }
+
+    private static string? ExtractProcessHint(string text)
+    {
+        var processPatterns = new[] { "process:", "exe:", "binary:", "program:", "via " };
+        foreach (var pattern in processPatterns)
+        {
+            var idx = text.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) continue;
+            var start = idx + pattern.Length;
+            var end = text.IndexOfAny(new[] { ' ', ',', ';', '\n' }, start);
+            if (end < 0) end = Math.Min(text.Length, start + 40);
+            var value = text[start..end].Trim();
+            if (!string.IsNullOrWhiteSpace(value)) return value;
+        }
+        return null;
+    }
+
+    private static string ExtractTargetHint(string text, string technique)
+    {
+        var targetPatterns = new[] { "target:", "collecting:", "data:", "file:", "from:" };
+        foreach (var pattern in targetPatterns)
+        {
+            var idx = text.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) continue;
+            var start = idx + pattern.Length;
+            var end = text.IndexOfAny(new[] { ',', ';', '\n' }, start);
+            if (end < 0) end = Math.Min(text.Length, start + 60);
+            var value = text[start..end].Trim();
+            if (!string.IsNullOrWhiteSpace(value)) return value;
+        }
+
+        // Default target based on technique
+        return technique switch
+        {
+            "Screen Capture" => "Display/screen content",
+            "Clipboard Data" => "Clipboard buffer",
+            "Keylogging" => "Keyboard input",
+            "GUI Input Capture" => "GUI credentials",
+            "Web Portal Capture" => "Web form data",
+            "Credential API Hooking" => "Authentication credentials",
+            "Local Data Staging" => "Local files",
+            "Remote Data Staging" => "Remote files",
+            "Local Email Collection" => "Local email data",
+            "Remote Email Collection" => "Remote mailbox data",
+            "Automated Collection" => "Bulk data",
+            "Archive via Utility" => "Compressed archives",
+            _ => "Unknown data"
+        };
+    }
+
+    private static List<CollectionCampaign> DetectCampaigns(List<CollectionEvent> events)
+    {
+        var campaigns = new List<CollectionCampaign>();
+        var byProcess = events
+            .GroupBy(e => e.SourceProcess.ToLowerInvariant())
+            .Where(g => !string.IsNullOrWhiteSpace(g.Key));
+
+        var campaignId = 0;
+        foreach (var group in byProcess)
+        {
+            var techniques = group.Select(e => e.TechniqueId).Distinct().ToList();
+            if (techniques.Count < 3) continue;
+
+            campaignId++;
+            campaigns.Add(new CollectionCampaign
+            {
+                CampaignId = $"CAMP-{campaignId:D4}",
+                SourceProcess = group.Key,
+                TechniquesUsed = techniques,
+                EventCount = group.Count(),
+                Severity = techniques.Count >= 5 ? "Critical" : "High",
+                Confidence = Math.Min(1.0, 0.7 + techniques.Count * 0.05)
+            });
+        }
+
+        return campaigns.OrderByDescending(c => c.TechniquesUsed.Count).ToList();
+    }
+
+    private static CollectionStats CalculateStats(List<CollectionEvent> events)
+    {
+        return new CollectionStats
+        {
+            TotalTechniquesDetected = events.Select(e => e.TechniqueId).Distinct().Count(),
+            UniqueProcesses = events.Select(e => e.SourceProcess).Distinct().Count(),
+            OffHoursActivities = events.Count(e => e.RiskFactors.Any(r => r.Contains("Off-hours"))),
+            HighVolumeCollections = events.Count(e => e.RiskFactors.Any(r => r.Contains("High volume"))),
+            AutomatedCollectionCount = events.Count(e => e.RiskFactors.Any(r => r.Contains("Automation"))),
+            SensitiveDataTargets = events.Count(e => e.RiskFactors.Any(r => r.Contains("Sensitive")))
+        };
+    }
+
+    private static double CalculateThreatScore(List<CollectionEvent> events, List<CollectionCampaign> campaigns)
+    {
+        if (events.Count == 0) return 0;
+
+        // Base score from event count and severity
+        var severityScore = events.Sum(e => e.Severity switch
+        {
+            "Critical" => 15.0,
+            "High" => 10.0,
+            "Medium" => 5.0,
+            _ => 2.0
+        });
+
+        // Technique diversity bonus
+        var techniqueCount = events.Select(e => e.TechniqueId).Distinct().Count();
+        var diversityBonus = techniqueCount * 5.0;
+
+        // Campaign bonus
+        var campaignBonus = campaigns.Sum(c => c.TechniquesUsed.Count * 5.0);
+
+        // Known tool bonus
+        var toolBonus = events.Count(e => e.RiskFactors.Any(r => r.StartsWith("Known tool"))) * 8.0;
+
+        var rawScore = severityScore + diversityBonus + campaignBonus + toolBonus;
+        return Math.Min(100, Math.Round(rawScore, 1));
+    }
+
+    private static List<CollectionRecommendation> GenerateRecommendations(
+        List<CollectionEvent> events, List<CollectionTechnique> techniques)
+    {
+        var recommendations = new List<CollectionRecommendation>();
+        var priority = 0;
+
+        if (techniques.Any(t => t.TechniqueId == "T1056.001"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "Input Protection",
+                Title = "Deploy anti-keylogging protection",
+                Description = "Implement kernel-level input protection to prevent unauthorized keystroke capture. Consider credential guard and protected process light.",
+                MitreTechnique = "T1056.001"
+            });
+        }
+
+        if (techniques.Any(t => t.TechniqueId == "T1115"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "Clipboard Security",
+                Title = "Monitor and restrict clipboard access",
+                Description = "Audit clipboard access by non-standard processes. Implement clipboard clearing for sensitive operations.",
+                MitreTechnique = "T1115"
+            });
+        }
+
+        if (techniques.Any(t => t.TechniqueId is "T1114.001" or "T1114.002"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "Email Protection",
+                Title = "Secure email storage and access",
+                Description = "Encrypt email archives, monitor mailbox access patterns, audit email forwarding rules, and restrict PST/OST file access.",
+                MitreTechnique = "T1114"
+            });
+        }
+
+        if (techniques.Any(t => t.TechniqueId == "T1113"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "Screen Protection",
+                Title = "Restrict screen capture capabilities",
+                Description = "Monitor screen capture API usage (BitBlt, PrintWindow), restrict unnecessary screen recording software.",
+                MitreTechnique = "T1113"
+            });
+        }
+
+        if (techniques.Any(t => t.TechniqueId is "T1074.001" or "T1074.002"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "Data Staging",
+                Title = "Monitor data staging locations",
+                Description = "Watch for unusual file accumulation in temp directories, network shares, and non-standard locations. Alert on bulk file copies.",
+                MitreTechnique = "T1074"
+            });
+        }
+
+        if (techniques.Any(t => t.TechniqueId == "T1560.001"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "Archive Control",
+                Title = "Monitor archive creation tools",
+                Description = "Alert on unexpected usage of compression utilities (7zip, WinRAR, tar). Monitor for large archive creation outside normal workflows.",
+                MitreTechnique = "T1560.001"
+            });
+        }
+
+        if (techniques.Any(t => t.TechniqueId == "T1119"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "Automation Defense",
+                Title = "Detect automated collection scripts",
+                Description = "Monitor for scripted data harvesting patterns including bulk file enumeration, recursive directory scanning, and scheduled collection tasks.",
+                MitreTechnique = "T1119"
+            });
+        }
+
+        if (techniques.Any(t => t.TechniqueId == "T1056.004"))
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "API Protection",
+                Title = "Protect credential APIs from hooking",
+                Description = "Enable Credential Guard, monitor LSASS access, implement Protected Process Light for sensitive authentication services.",
+                MitreTechnique = "T1056.004"
+            });
+        }
+
+        // General recommendation if any events
+        if (events.Count > 0 && recommendations.Count < 3)
+        {
+            recommendations.Add(new CollectionRecommendation
+            {
+                Priority = ++priority,
+                Category = "General",
+                Title = "Enable comprehensive DLP monitoring",
+                Description = "Deploy Data Loss Prevention (DLP) sensors to detect and prevent unauthorized data collection activities across endpoints.",
+                MitreTechnique = "TA0009"
+            });
+        }
+
+        return recommendations;
+    }
+}

--- a/tests/WinSentinel.Tests/CollectionDetectorTests.cs
+++ b/tests/WinSentinel.Tests/CollectionDetectorTests.cs
@@ -1,0 +1,639 @@
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Services;
+
+namespace WinSentinel.Tests;
+
+public class CollectionDetectorTests
+{
+    private static AuditHistoryService MakeHistory() => new();
+
+    private static SecurityReport MakeReport(params (string module, Finding[] findings)[] modules)
+    {
+        var report = new SecurityReport();
+        foreach (var (module, findings) in modules)
+        {
+            report.Results.Add(new AuditResult
+            {
+                ModuleName = module,
+                Category = module,
+                Findings = findings.ToList()
+            });
+        }
+        return report;
+    }
+
+    private static Finding MakeFinding(string title, string desc = "",
+        Severity severity = Severity.Warning) => new()
+    {
+        Title = title,
+        Description = desc,
+        Category = "Security"
+    };
+
+    [Fact]
+    public void EmptyReport_ReturnsZeroThreatScore()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport();
+        var result = detector.Detect(report);
+
+        Assert.Equal(0, result.ThreatScore);
+        Assert.Equal("Minimal", result.ThreatLevel);
+        Assert.Empty(result.Events);
+    }
+
+    [Fact]
+    public void NoCollectionKeywords_ReturnsNoDetections()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Network", new[]
+        {
+            MakeFinding("Normal HTTP traffic detected", "Regular web browsing activity")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.Equal(0, result.CollectionActivitiesDetected);
+    }
+
+    [Fact]
+    public void ScreenCapture_DetectsT1113()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Screenshot utility detected", "Process taking screen capture via BitBlt")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1113");
+    }
+
+    [Fact]
+    public void ClipboardData_DetectsT1115()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Clipboard monitor installed", "Process hooking clipboard capture events")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1115");
+    }
+
+    [Fact]
+    public void Keylogging_DetectsT1056_001()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger detected", "SetWindowsHookEx keyboard hook installed by suspicious process")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1056.001");
+    }
+
+    [Fact]
+    public void GUIInputCapture_DetectsT1056_002()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Fake credential dialog spawned", "GUI capture of user credentials via phishing dialog")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1056.002");
+    }
+
+    [Fact]
+    public void WebPortalCapture_DetectsT1056_003()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Network", new[]
+        {
+            MakeFinding("Browser form capture detected", "Web portal credential form grab via injected script")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1056.003");
+    }
+
+    [Fact]
+    public void CredentialAPIHooking_DetectsT1056_004()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("LSASS hook detected", "Credential API hooking via SSPI hook on authentication")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1056.004");
+    }
+
+    [Fact]
+    public void LocalDataStaging_DetectsT1074_001()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("FileSystem", new[]
+        {
+            MakeFinding("Suspicious data staging folder", "Files being collected in local staging directory")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1074.001");
+    }
+
+    [Fact]
+    public void RemoteDataStaging_DetectsT1074_002()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Network", new[]
+        {
+            MakeFinding("Network share staging activity", "SMB staging of collected data to shared drive")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1074.002");
+    }
+
+    [Fact]
+    public void LocalEmailCollection_DetectsT1114_001()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("PST file access detected", "Local email archive mailbox export from Outlook data")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1114.001");
+    }
+
+    [Fact]
+    public void RemoteEmailCollection_DetectsT1114_002()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Network", new[]
+        {
+            MakeFinding("Exchange harvest attempt", "Remote email collection via OWA scrape with forwarding rule")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1114.002");
+    }
+
+    [Fact]
+    public void AutomatedCollection_DetectsT1119()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Automated collection script", "Scripted harvest of sensitive files via bulk collect")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1119");
+    }
+
+    [Fact]
+    public void ArchiveViaUtility_DetectsT1560_001()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("7zip archive creation", "Data compressed with 7zip before exfil attempt")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.TechniqueId == "T1560.001");
+    }
+
+    [Fact]
+    public void KnownTool_Lazagne_BoostsConfidence()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("LaZagne clipboard credential extraction", "lazagne tool detected accessing clipboard data")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        var ev = result.Events.First();
+        Assert.Contains(ev.RiskFactors, r => r.Contains("Known tool"));
+        Assert.True(ev.Confidence > 0.8);
+    }
+
+    [Fact]
+    public void KnownTool_Mimikatz_BoostsConfidence()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Mimikatz credential hook", "mimikatz clipboard capture module active")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.RiskFactors.Any(r => r.Contains("mimikatz")));
+    }
+
+    [Fact]
+    public void KnownTool_PowerSploit_Detected()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("PowerSploit screen capture module", "powersploit Get-TimedScreenshot taking display capture")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.RiskFactors.Any(r => r.Contains("powersploit")));
+    }
+
+    [Fact]
+    public void SensitiveTarget_Email_BoostsConfidence()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Email credential clipboard capture", "Clipboard data containing email password intercepted")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.RiskFactors.Any(r => r.Contains("Sensitive")));
+    }
+
+    [Fact]
+    public void SensitiveTarget_Financial_BoostsConfidence()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Financial data keylogging", "Keylogger capturing financial and bank credentials")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.RiskFactors.Any(r => r.Contains("Sensitive")));
+    }
+
+    [Fact]
+    public void HighVolume_BoostsConfidence()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Bulk data collection detected", "Mass clipboard data harvest from all files")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.RiskFactors.Any(r => r.Contains("High volume")));
+    }
+
+    [Fact]
+    public void AutomationIndicator_BoostsConfidence()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Scheduled screenshot task", "Automated screen capture via task scheduler at interval")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.CollectionActivitiesDetected > 0);
+        Assert.Contains(result.Events, e => e.RiskFactors.Any(r => r.Contains("Automation")));
+    }
+
+    [Fact]
+    public void CampaignDetection_MultipleTechniques_SameProcess()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger via process: malware.exe", "keystroke capture from keyboard hook"),
+            MakeFinding("Screenshot via process: malware.exe", "screen capture from display capture"),
+            MakeFinding("Clipboard via process: malware.exe", "clipboard monitor data intercepted"),
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.Campaigns.Count > 0);
+        Assert.Contains(result.Campaigns, c => c.TechniquesUsed.Count >= 3);
+    }
+
+    [Fact]
+    public void CampaignDetection_TwoTechniques_NoCampaign()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger via process: tool.exe", "keystroke capture"),
+            MakeFinding("Screenshot via process: tool.exe", "screen capture"),
+        }));
+        var result = detector.Detect(report);
+
+        // 2 techniques from same process is NOT enough for a campaign (requires 3+)
+        Assert.Empty(result.Campaigns);
+    }
+
+    [Fact]
+    public void ThreatLevel_Minimal_WhenNoEvents()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport();
+        var result = detector.Detect(report);
+
+        Assert.Equal("Minimal", result.ThreatLevel);
+    }
+
+    [Fact]
+    public void ThreatLevel_Increases_WithMoreEvents()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger active", "keystroke capture via keyboard hook"),
+            MakeFinding("Screen capture running", "screenshot display capture ongoing"),
+            MakeFinding("Clipboard hooked", "clipboard monitor clipboard capture active"),
+            MakeFinding("Email archive accessed", "PST file local email collection"),
+            MakeFinding("7zip archiving data", "archive collected compress data for exfil"),
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.ThreatScore > 20);
+        Assert.NotEqual("Minimal", result.ThreatLevel);
+    }
+
+    [Fact]
+    public void ThreatScore_ZeroForEmptyReport()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var result = detector.Detect(MakeReport());
+        Assert.Equal(0, result.ThreatScore);
+    }
+
+    [Fact]
+    public void ThreatScore_CappedAt100()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var findings = Enumerable.Range(0, 50).Select(i =>
+            MakeFinding($"Keylogger instance {i} via process: malware.exe",
+                $"keystroke capture keyboard hook mimikatz credential password #{i}")).ToArray();
+        var report = MakeReport(("Endpoint", findings));
+        var result = detector.Detect(report);
+
+        Assert.True(result.ThreatScore <= 100);
+    }
+
+    [Fact]
+    public void Recommendations_Generated_ForKeylogging()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger detected", "keystroke capture via keyboard hook")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.Recommendations.Count > 0);
+        Assert.Contains(result.Recommendations, r => r.MitreTechnique == "T1056.001");
+    }
+
+    [Fact]
+    public void Recommendations_Generated_ForClipboard()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Clipboard hook installed", "clipboard capture active")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.Contains(result.Recommendations, r => r.MitreTechnique == "T1115");
+    }
+
+    [Fact]
+    public void Recommendations_Generated_ForEmail()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("PST export detected", "local email pst file access")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.Contains(result.Recommendations, r => r.MitreTechnique == "T1114");
+    }
+
+    [Fact]
+    public void Recommendations_Generated_ForArchive()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("WinRAR compression", "winrar archive collected data compressed")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.Contains(result.Recommendations, r => r.MitreTechnique == "T1560.001");
+    }
+
+    [Fact]
+    public void TechniqueAggregation_GroupsByTechniqueId()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("First screenshot", "screen capture display capture"),
+            MakeFinding("Second screenshot", "another screen capture taken"),
+        }));
+        var result = detector.Detect(report);
+
+        var t1113 = result.Techniques.FirstOrDefault(t => t.TechniqueId == "T1113");
+        Assert.NotNull(t1113);
+        Assert.True(t1113.EventCount >= 2);
+    }
+
+    [Fact]
+    public void Stats_UniqueProcesses_CountedCorrectly()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(
+            ("ModuleA", new[] { MakeFinding("Keylogger", "keystroke capture keyboard hook") }),
+            ("ModuleB", new[] { MakeFinding("Screenshot", "screen capture display capture") })
+        );
+        var result = detector.Detect(report);
+
+        Assert.True(result.Stats.UniqueProcesses >= 2);
+    }
+
+    [Fact]
+    public void Stats_TotalTechniquesDetected_IsCorrect()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger", "keystroke keyboard hook"),
+            MakeFinding("Screenshot", "screen capture"),
+            MakeFinding("Clipboard", "clipboard monitor"),
+        }));
+        var result = detector.Detect(report);
+
+        Assert.True(result.Stats.TotalTechniquesDetected >= 3);
+    }
+
+    [Fact]
+    public void SeverityCount_CorrectlyClassified()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger", "keystroke keyboard hook mimikatz credential"),
+            MakeFinding("Clipboard", "clipboard monitor"),
+        }));
+        var result = detector.Detect(report);
+
+        var totalSeverity = result.HighSeverityCount + result.MediumSeverityCount + result.LowSeverityCount;
+        Assert.Equal(result.CollectionActivitiesDetected, totalSeverity);
+    }
+
+    [Fact]
+    public void MultipleKeywordsInSameFinding_SingleDetection()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Screenshot and screen grab", "screen capture with display capture and snipping")
+        }));
+        var result = detector.Detect(report);
+
+        // Should detect T1113 once (not multiple times for same technique)
+        var t1113Events = result.Events.Count(e => e.TechniqueId == "T1113");
+        Assert.Equal(1, t1113Events);
+    }
+
+    [Fact]
+    public void DaysAnalyzed_PropagatedCorrectly()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var result = detector.Detect(MakeReport(), 30);
+        Assert.Equal(30, result.DaysAnalyzed);
+    }
+
+    [Fact]
+    public void EventsProcessed_MatchesFindingCount()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("A", new[]
+        {
+            MakeFinding("F1", "normal stuff"),
+            MakeFinding("F2", "more normal")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.Equal(2, result.EventsProcessed);
+    }
+
+    [Fact]
+    public void ConfidenceScore_BetweenZeroAndOne()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Major keylogger campaign", "keystroke keyboard hook lazagne mimikatz credential password bulk automated")
+        }));
+        var result = detector.Detect(report);
+
+        foreach (var ev in result.Events)
+        {
+            Assert.True(ev.Confidence >= 0 && ev.Confidence <= 1.0);
+        }
+    }
+
+    [Fact]
+    public void TargetData_DefaultsBasedOnTechnique()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Keylogger found", "keystroke keyboard hook active")
+        }));
+        var result = detector.Detect(report);
+
+        var ev = result.Events.FirstOrDefault(e => e.TechniqueId == "T1056.001");
+        Assert.NotNull(ev);
+        Assert.False(string.IsNullOrEmpty(ev.TargetData));
+    }
+
+    [Fact]
+    public void ContextIndicators_ContainMatchedKeywords()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Screenshot tool", "display capture and screen grab utility")
+        }));
+        var result = detector.Detect(report);
+
+        var ev = result.Events.FirstOrDefault(e => e.TechniqueId == "T1113");
+        Assert.NotNull(ev);
+        Assert.True(ev.ContextIndicators.Count > 0);
+    }
+
+    [Fact]
+    public void GeneratedAt_IsRecentTimestamp()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var result = detector.Detect(MakeReport());
+
+        Assert.True(result.GeneratedAt > DateTimeOffset.UtcNow.AddMinutes(-5));
+    }
+
+    [Fact]
+    public void CredentialAPIHooking_HighConfidence()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("SSPI credential hook", "credential api sspi hook intercepting auth")
+        }));
+        var result = detector.Detect(report);
+
+        var ev = result.Events.FirstOrDefault(e => e.TechniqueId == "T1056.004");
+        Assert.NotNull(ev);
+        Assert.True(ev.Confidence >= 0.85);
+    }
+
+    [Fact]
+    public void CombinedRiskFactors_IncreasesSeverity()
+    {
+        var detector = new CollectionDetector(MakeHistory());
+        var report = MakeReport(("Endpoint", new[]
+        {
+            MakeFinding("Lazagne keylogger on sensitive data",
+                "lazagne keystroke keyboard hook credential financial password")
+        }));
+        var result = detector.Detect(report);
+
+        Assert.Contains(result.Events, e =>
+            e.Severity == "High" || e.Severity == "Critical");
+    }
+}


### PR DESCRIPTION
## Collection Detector — Autonomous MITRE ATT&CK TA0009 Detection

Detects 12 collection techniques:
- T1113: Screen Capture
- T1115: Clipboard Data  
- T1056.001: Keylogging
- T1056.002: GUI Input Capture
- T1056.003: Web Portal Capture
- T1056.004: Credential API Hooking
- T1074.001: Local Data Staging
- T1074.002: Remote Data Staging
- T1114.001: Local Email Collection
- T1114.002: Remote Email Collection
- T1119: Automated Collection
- T1560.001: Archive via Utility

### Features
- Known tool detection (lazagne, mimikatz, powersploit, empire, etc.)
- Campaign detection (3+ techniques from same process)
- Risk factor boosters (off-hours, sensitive targets, automation, volume)
- Confidence scoring with composite threat score 0-100
- 5-tier threat classification (Minimal/Low/Moderate/High/Critical)
- Actionable recommendations per detected technique
- CLI subcommand with filtering and JSON output

### Usage
\\\ash
winsentinel collection
winsentinel collection --collection-days 90 --json
winsentinel collection --collection-severity High --collection-top 10
\\\

### Tests
44 tests covering all techniques, campaign detection, scoring, and recommendations.