### PR TITLE
feat(plugins): interface guard, fingerprint display, entitlement vocabulary

### DIFF
--- a/src/WinSentinel.Cli/PluginCommandHandler.cs
+++ b/src/WinSentinel.Cli/PluginCommandHandler.cs
@@ -81,7 +81,10 @@ internal static class PluginCommandHandler
             foreach (var p in trust.TrustedPublishers)
             {
                 var tag = p.AutoTrusted ? " [official]" : string.Empty;
-                Console.WriteLine($"  - {p.Name}{tag}  {Short(p.PublicKey)}");
+                var fp = Ed25519Crypto.FingerprintShort(p.PublicKey) ?? "(invalid key)";
+                Console.WriteLine($"  - {p.Name}{tag}");
+                Console.WriteLine($"      key:         {Short(p.PublicKey)}");
+                Console.WriteLine($"      fingerprint: {fp}");
             }
         }
         Console.WriteLine();
@@ -97,7 +100,12 @@ internal static class PluginCommandHandler
                 var name = Path.GetFileName(r.DllPath);
                 Console.WriteLine($"  [{r.Status}] {name}");
                 if (!string.IsNullOrEmpty(r.FeatureId)) Console.WriteLine($"      feature:   {r.FeatureId} v{r.Version}");
-                if (!string.IsNullOrEmpty(r.PublisherName)) Console.WriteLine($"      publisher: {r.PublisherName}  {Short(r.PublisherKey)}");
+                if (!string.IsNullOrEmpty(r.PublisherName))
+                {
+                    var pfp = Ed25519Crypto.FingerprintShort(r.PublisherKey) ?? "";
+                    Console.WriteLine($"      publisher: {r.PublisherName}  {Short(r.PublisherKey)}");
+                    if (!string.IsNullOrEmpty(pfp)) Console.WriteLine($"      fp:        {pfp}");
+                }
                 Console.WriteLine($"      detail:    {r.Message}");
             }
         }
@@ -134,7 +142,10 @@ internal static class PluginCommandHandler
         try
         {
             var entry = TrustedPublisherStore.Trust(options.PluginPublisherName!, options.PluginPublisherKey!);
-            Console.WriteLine($"Trusted publisher '{entry.Name}' added ({Short(entry.PublicKey)}).");
+            var fp = Ed25519Crypto.FingerprintShort(entry.PublicKey) ?? "(unknown)";
+            Console.WriteLine($"Trusted publisher '{entry.Name}' added.");
+            Console.WriteLine($"  key:         {Short(entry.PublicKey)}");
+            Console.WriteLine($"  fingerprint: {fp}");
             if (options.PluginAllowUnsigned.HasValue)
             {
                 TrustedPublisherStore.SetAllowUnsigned(options.PluginAllowUnsigned.Value);

--- a/src/WinSentinel.Core/Plugins/Ed25519Crypto.cs
+++ b/src/WinSentinel.Core/Plugins/Ed25519Crypto.cs
@@ -88,4 +88,29 @@ public static class Ed25519Crypto
         signer.BlockUpdate(message, 0, message.Length);
         return signer.GenerateSignature();
     }
+
+    /// <summary>
+    /// Computes the SHA-256 fingerprint of a base64-encoded public key.
+    /// Returns a colon-separated hex string like <c>SHA256:ab:cd:ef:...</c>.
+    /// Returns <c>null</c> if the input is invalid.
+    /// </summary>
+    public static string? Fingerprint(string? publicKeyBase64)
+    {
+        var bytes = TryDecodeBase64(publicKeyBase64);
+        if (bytes is null || bytes.Length != PublicKeySize) return null;
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return "SHA256:" + BitConverter.ToString(hash).Replace("-", ":").ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Short fingerprint: first 8 bytes (16 hex chars) of the SHA-256.
+    /// Suitable for display in trust prompts.
+    /// </summary>
+    public static string? FingerprintShort(string? publicKeyBase64)
+    {
+        var bytes = TryDecodeBase64(publicKeyBase64);
+        if (bytes is null || bytes.Length != PublicKeySize) return null;
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return "SHA256:" + BitConverter.ToString(hash, 0, 8).Replace("-", ":").ToLowerInvariant();
+    }
 }

--- a/src/WinSentinel.Core/Plugins/PluginEntitlements.cs
+++ b/src/WinSentinel.Core/Plugins/PluginEntitlements.cs
@@ -1,0 +1,110 @@
+namespace WinSentinel.Core.Plugins;
+
+/// <summary>
+/// Canonical plugin entitlement (capability) identifiers. These are the
+/// string values referenced in <c>plugin.json</c> manifests under
+/// <c>"entitlements"</c> and checked at load time by the plugin host.
+///
+/// <para><b>Convention:</b> all entitlements use dot-separated lowercase
+/// with the pattern <c>winsentinel.{category}.{action}</c>.</para>
+///
+/// <para>Adding new entitlements is a semver-minor change. Removing or
+/// redefining an entitlement is a semver-major breaking change.</para>
+///
+/// Issue: #198
+/// </summary>
+public static class PluginEntitlements
+{
+    // ─── Audit Module ──────────────────────────────────────────────
+    /// <summary>Permission to register a custom audit module.</summary>
+    public const string AuditModule = "winsentinel.audit.module";
+
+    /// <summary>Permission to access audit results from other modules.</summary>
+    public const string AuditRead = "winsentinel.audit.read";
+
+    // ─── Monitor ───────────────────────────────────────────────────
+    /// <summary>Permission to register a real-time monitor daemon.</summary>
+    public const string MonitorDaemon = "winsentinel.monitor.daemon";
+
+    // ─── Reporting ─────────────────────────────────────────────────
+    /// <summary>Permission to register a report export format.</summary>
+    public const string ReportExporter = "winsentinel.report.exporter";
+
+    // ─── Compliance ────────────────────────────────────────────────
+    /// <summary>Permission to register a compliance mapper/profile.</summary>
+    public const string ComplianceMapper = "winsentinel.compliance.mapper";
+
+    // ─── Fleet / Remote ────────────────────────────────────────────
+    /// <summary>Permission to register a fleet telemetry sink.</summary>
+    public const string FleetSink = "winsentinel.fleet.sink";
+
+    // ─── Scheduling ────────────────────────────────────────────────
+    /// <summary>Permission to register scheduled scan logic.</summary>
+    public const string ScheduledScan = "winsentinel.scan.scheduled";
+
+    // ─── System Access (elevated) ──────────────────────────────────
+    /// <summary>Permission to read the Windows registry.</summary>
+    public const string SystemRegistryRead = "winsentinel.system.registry.read";
+
+    /// <summary>Permission to write the Windows registry (remediation).</summary>
+    public const string SystemRegistryWrite = "winsentinel.system.registry.write";
+
+    /// <summary>Permission to execute shell commands.</summary>
+    public const string SystemExec = "winsentinel.system.exec";
+
+    /// <summary>Permission to access the filesystem beyond the plugin's own directory.</summary>
+    public const string SystemFileAccess = "winsentinel.system.file";
+
+    /// <summary>Permission to make outbound network connections.</summary>
+    public const string SystemNetwork = "winsentinel.system.network";
+
+    // ─── UI / Notification ─────────────────────────────────────────
+    /// <summary>Permission to send toast / system notifications.</summary>
+    public const string Notify = "winsentinel.ui.notify";
+
+    // ─── Storage ───────────────────────────────────────────────────
+    /// <summary>Permission to persist data in the WinSentinel SQLite database.</summary>
+    public const string StorageDb = "winsentinel.storage.db";
+
+    /// <summary>All known entitlements for validation/display purposes.</summary>
+    public static readonly string[] All =
+    [
+        AuditModule,
+        AuditRead,
+        MonitorDaemon,
+        ReportExporter,
+        ComplianceMapper,
+        FleetSink,
+        ScheduledScan,
+        SystemRegistryRead,
+        SystemRegistryWrite,
+        SystemExec,
+        SystemFileAccess,
+        SystemNetwork,
+        Notify,
+        StorageDb,
+    ];
+
+    /// <summary>
+    /// Returns true if the given entitlement string is a recognized value.
+    /// Unknown entitlements should be rejected at plugin load time.
+    /// </summary>
+    public static bool IsKnown(string? entitlement)
+        => !string.IsNullOrWhiteSpace(entitlement) && Array.IndexOf(All, entitlement) >= 0;
+
+    /// <summary>
+    /// Entitlements that grant system-level access. Plugins requesting these
+    /// should trigger an elevated trust prompt.
+    /// </summary>
+    public static readonly string[] Elevated =
+    [
+        SystemRegistryWrite,
+        SystemExec,
+        SystemFileAccess,
+        SystemNetwork,
+    ];
+
+    /// <summary>Returns true if the entitlement is considered elevated/dangerous.</summary>
+    public static bool IsElevated(string? entitlement)
+        => !string.IsNullOrWhiteSpace(entitlement) && Array.IndexOf(Elevated, entitlement) >= 0;
+}

--- a/tests/WinSentinel.Tests/Plugins/FingerprintTests.cs
+++ b/tests/WinSentinel.Tests/Plugins/FingerprintTests.cs
@@ -1,0 +1,86 @@
+using WinSentinel.Core.Plugins;
+
+namespace WinSentinel.Tests.Plugins;
+
+/// <summary>
+/// Tests for Ed25519Crypto.Fingerprint and FingerprintShort methods.
+/// Issue: #197
+/// </summary>
+[Trait("Category", "BVT")]
+public class FingerprintTests
+{
+    [Fact]
+    public void Fingerprint_ValidKey_ReturnsSha256ColonSeparated()
+    {
+        var (pub, _) = Ed25519Crypto.GenerateKeypair();
+        var b64 = Convert.ToBase64String(pub);
+
+        var fp = Ed25519Crypto.Fingerprint(b64);
+
+        Assert.NotNull(fp);
+        Assert.StartsWith("SHA256:", fp);
+        // Full SHA-256 = 32 bytes = 64 hex chars + 31 colons = 95 chars + "SHA256:" prefix
+        Assert.Equal(7 + 95, fp!.Length);
+        // All lowercase hex + colons
+        Assert.Matches(@"^SHA256:[0-9a-f:]+$", fp);
+    }
+
+    [Fact]
+    public void FingerprintShort_ValidKey_Returns8BytePrefix()
+    {
+        var (pub, _) = Ed25519Crypto.GenerateKeypair();
+        var b64 = Convert.ToBase64String(pub);
+
+        var fp = Ed25519Crypto.FingerprintShort(b64);
+
+        Assert.NotNull(fp);
+        Assert.StartsWith("SHA256:", fp);
+        // 8 bytes = 16 hex chars + 7 colons = 23 chars + "SHA256:" prefix
+        Assert.Equal(7 + 23, fp!.Length);
+    }
+
+    [Fact]
+    public void Fingerprint_NullInput_ReturnsNull()
+    {
+        Assert.Null(Ed25519Crypto.Fingerprint(null));
+        Assert.Null(Ed25519Crypto.FingerprintShort(null));
+    }
+
+    [Fact]
+    public void Fingerprint_InvalidBase64_ReturnsNull()
+    {
+        Assert.Null(Ed25519Crypto.Fingerprint("not-valid-base64!!!"));
+        Assert.Null(Ed25519Crypto.FingerprintShort("not-valid-base64!!!"));
+    }
+
+    [Fact]
+    public void Fingerprint_WrongKeyLength_ReturnsNull()
+    {
+        var shortKey = Convert.ToBase64String(new byte[16]);
+        Assert.Null(Ed25519Crypto.Fingerprint(shortKey));
+    }
+
+    [Fact]
+    public void Fingerprint_Deterministic()
+    {
+        var (pub, _) = Ed25519Crypto.GenerateKeypair();
+        var b64 = Convert.ToBase64String(pub);
+
+        var fp1 = Ed25519Crypto.Fingerprint(b64);
+        var fp2 = Ed25519Crypto.Fingerprint(b64);
+
+        Assert.Equal(fp1, fp2);
+    }
+
+    [Fact]
+    public void FingerprintShort_IsPrefixOfFull()
+    {
+        var (pub, _) = Ed25519Crypto.GenerateKeypair();
+        var b64 = Convert.ToBase64String(pub);
+
+        var full = Ed25519Crypto.Fingerprint(b64)!;
+        var short_ = Ed25519Crypto.FingerprintShort(b64)!;
+
+        Assert.StartsWith(short_, full);
+    }
+}

--- a/tests/WinSentinel.Tests/Plugins/PluginEntitlementsTests.cs
+++ b/tests/WinSentinel.Tests/Plugins/PluginEntitlementsTests.cs
@@ -1,0 +1,77 @@
+using WinSentinel.Core.Plugins;
+
+namespace WinSentinel.Tests.Plugins;
+
+/// <summary>
+/// Tests for the PluginEntitlements vocabulary.
+/// Issue: #198
+/// </summary>
+[Trait("Category", "BVT")]
+public class PluginEntitlementsTests
+{
+    [Fact]
+    public void All_ContainsExpectedEntitlements()
+    {
+        Assert.Contains(PluginEntitlements.AuditModule, PluginEntitlements.All);
+        Assert.Contains(PluginEntitlements.MonitorDaemon, PluginEntitlements.All);
+        Assert.Contains(PluginEntitlements.ReportExporter, PluginEntitlements.All);
+        Assert.Contains(PluginEntitlements.SystemExec, PluginEntitlements.All);
+        Assert.Contains(PluginEntitlements.SystemNetwork, PluginEntitlements.All);
+        Assert.Contains(PluginEntitlements.StorageDb, PluginEntitlements.All);
+    }
+
+    [Fact]
+    public void IsKnown_RecognizesAllDefined()
+    {
+        foreach (var e in PluginEntitlements.All)
+        {
+            Assert.True(PluginEntitlements.IsKnown(e), $"{e} should be known");
+        }
+    }
+
+    [Fact]
+    public void IsKnown_RejectsUnknown()
+    {
+        Assert.False(PluginEntitlements.IsKnown("winsentinel.fake.thing"));
+        Assert.False(PluginEntitlements.IsKnown(null));
+        Assert.False(PluginEntitlements.IsKnown(""));
+        Assert.False(PluginEntitlements.IsKnown("  "));
+    }
+
+    [Fact]
+    public void IsElevated_IdentifiesDangerousEntitlements()
+    {
+        Assert.True(PluginEntitlements.IsElevated(PluginEntitlements.SystemExec));
+        Assert.True(PluginEntitlements.IsElevated(PluginEntitlements.SystemRegistryWrite));
+        Assert.True(PluginEntitlements.IsElevated(PluginEntitlements.SystemFileAccess));
+        Assert.True(PluginEntitlements.IsElevated(PluginEntitlements.SystemNetwork));
+    }
+
+    [Fact]
+    public void IsElevated_SafeEntitlementsReturnFalse()
+    {
+        Assert.False(PluginEntitlements.IsElevated(PluginEntitlements.AuditModule));
+        Assert.False(PluginEntitlements.IsElevated(PluginEntitlements.ReportExporter));
+        Assert.False(PluginEntitlements.IsElevated(PluginEntitlements.Notify));
+        Assert.False(PluginEntitlements.IsElevated(null));
+    }
+
+    [Theory]
+    [InlineData(PluginEntitlements.AuditModule)]
+    [InlineData(PluginEntitlements.MonitorDaemon)]
+    [InlineData(PluginEntitlements.SystemExec)]
+    public void Entitlements_FollowNamingConvention(string entitlement)
+    {
+        // Must be dot-separated lowercase: winsentinel.{category}.{action}
+        Assert.StartsWith("winsentinel.", entitlement);
+        Assert.Equal(entitlement, entitlement.ToLowerInvariant());
+        Assert.True(entitlement.Split('.').Length >= 3, "Must have at least 3 segments");
+    }
+
+    [Fact]
+    public void All_NoDuplicates()
+    {
+        var unique = new HashSet<string>(PluginEntitlements.All);
+        Assert.Equal(PluginEntitlements.All.Length, unique.Count);
+    }
+}

--- a/tests/WinSentinel.Tests/Plugins/PluginInterfaceVisibilityTests.cs
+++ b/tests/WinSentinel.Tests/Plugins/PluginInterfaceVisibilityTests.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+using WinSentinel.Core.Audits;
+using WinSentinel.Core.Interfaces;
+using WinSentinel.Core.Models;
+using WinSentinel.Core.Plugins;
+
+namespace WinSentinel.Tests.Plugins;
+
+/// <summary>
+/// Verifies all plugin-facing interfaces and types remain public in the Core assembly.
+/// Prevents accidental visibility regressions that would break third-party plugins.
+/// Issue: #215
+/// </summary>
+[Trait("Category", "BVT")]
+public class PluginInterfaceVisibilityTests
+{
+    private static readonly Type[] RequiredPublicTypes =
+    [
+        typeof(IWinSentinelPlugin),
+        typeof(IPluginContext),
+        typeof(IAuditModule),
+        typeof(IComplianceMapper),
+        typeof(IReportExporter),
+        typeof(IMonitorDaemon),
+        typeof(IFleetSink),
+        typeof(IScheduledScan),
+        typeof(PluginLogLevel),
+        typeof(PluginLoadStatus),
+    ];
+
+    [Fact]
+    public void AllPluginInterfaces_ArePublic()
+    {
+        foreach (var type in RequiredPublicTypes)
+        {
+            Assert.True(type.IsPublic, $"{type.FullName} must be public for plugin authors");
+        }
+    }
+
+    [Fact]
+    public void CoreModels_UsedByPlugins_ArePublic()
+    {
+        // Models that plugin authors need to construct/return
+        var modelTypes = new[]
+        {
+            typeof(Finding),
+            typeof(Severity),
+            typeof(AuditResult),
+            typeof(SecurityReport),
+            typeof(FixResult),
+        };
+
+        foreach (var type in modelTypes)
+        {
+            Assert.True(type.IsPublic, $"{type.FullName} must be public for plugin authors");
+        }
+    }
+
+    [Fact]
+    public void AuditModuleBase_IsPublic()
+    {
+        var type = typeof(AuditModuleBase);
+        Assert.True(type.IsPublic, "AuditModuleBase must be public so plugins can extend it");
+        Assert.True(type.IsAbstract, "AuditModuleBase must remain abstract");
+    }
+
+    [Fact]
+    public void IPluginContext_ExposesRequiredMembers()
+    {
+        var contextType = typeof(IPluginContext);
+        var members = contextType.GetMembers(BindingFlags.Public | BindingFlags.Instance);
+
+        // Must have Log property
+        Assert.Contains(members, m => m.Name == "Log");
+        // Must have Config property
+        Assert.Contains(members, m => m.Name == "Config");
+    }
+}


### PR DESCRIPTION
## Summary

Three plugin architecture issues - all tested and passing.

### #215 - Verify plugin interfaces are public in Core NuGet
- Added regression test (PluginInterfaceVisibilityTests) asserting all plugin-facing types stay public
- Confirmed: IWinSentinelPlugin, IPluginContext, IAuditModule, IComplianceMapper, IReportExporter, IMonitorDaemon, IFleetSink, IScheduledScan, AuditModuleBase, and core models are all public

### #197 - Display fingerprint in plugin trust flow
- Added Ed25519Crypto.Fingerprint() / FingerprintShort() - SHA-256 of raw public key bytes
- `plugin list` now shows fingerprint per publisher
- `plugin trust` success message shows fingerprint
- 7 new tests

### #198 - Plugin entitlement vocabulary
- New PluginEntitlements class with 14 canonical capability IDs
- Convention: `winsentinel.{category}.{action}` (lowercase, dot-separated)
- IsKnown() + IsElevated() helpers for load-time validation
- 9 new tests

**Total: 20 new tests, all BVT-tagged.**

Closes #215, closes #197, closes #198
